### PR TITLE
Pathlib stuff

### DIFF
--- a/basic_features/basic_save_game_info.py
+++ b/basic_features/basic_save_game_info.py
@@ -21,7 +21,7 @@ class BasicGameSaveGame(mobase.ISaveGame):
         return self._filename
 
     def getCreationTime(self):
-        return QDateTime(Path(self._filename).stat().st_ctime)
+        return QDateTime(Path(self._filename).stat().st_mtime)
 
     def getSaveGroupIdentifier(self):
         return ""

--- a/basic_features/basic_save_game_info.py
+++ b/basic_features/basic_save_game_info.py
@@ -1,8 +1,8 @@
 # -*- encoding: utf-8 -*-
 
-import os
 import sys
 
+from pathlib import Path
 from typing import Callable, Optional
 
 from PyQt5.QtCore import QDateTime, Qt
@@ -21,7 +21,7 @@ class BasicGameSaveGame(mobase.ISaveGame):
         return self._filename
 
     def getCreationTime(self):
-        return QDateTime(os.path.getmtime(self._filename))
+        return QDateTime(Path(self._filename).stat().st_ctime)
 
     def getSaveGroupIdentifier(self):
         return ""
@@ -62,7 +62,9 @@ class BasicGameSaveGameInfoWidget(mobase.ISaveGameInfoWidget):
         if value is None:
             return
 
-        if isinstance(value, str):
+        if isinstance(value, Path):
+            pixmap = QPixmap(str(value))
+        elif isinstance(value, str):
             pixmap = QPixmap(value)
         elif isinstance(value, QPixmap):
             pixmap = value


### PR DESCRIPTION
`os.path` is old and less safe than Pathlib, so I removed it while I wanted to meddle with this file anyway.

It looked suspicious that `getCreationTime` was returning the modification time instead of the creation time, so I changed that from `mtime` to `ctime`.

I also added handling for `value` being a `Path` object as that's the type for the thing it represents. I might not have needed the explicit `str` call as Path is implicitly convertible to `str` lots of the time, but I've not actually tested the change so wanted to play it safe.