### PR TITLE
Add robustness to reading Steam manifest files

### DIFF
--- a/steam_utils.py
+++ b/steam_utils.py
@@ -8,6 +8,8 @@ import winreg  # type: ignore
 from pathlib import Path
 from typing import Dict
 
+from PyQt5.QtCore import qWarning
+
 
 class SteamGame:
     def __init__(self, appid, installdir):
@@ -28,23 +30,25 @@ class LibraryFolder:
         self.games = []
         for filename in os.listdir(os.path.join(path, "steamapps")):
             if filename.startswith("appmanifest"):
-                with open(
-                    os.path.join(path, "steamapps", filename), "r", encoding="utf-8"
-                ) as fp:
-                    i, n = None, None
-                    for line in fp:
-                        line = line.strip()
+                filepath = os.path.join(path, "steamapps", filename)
+                try:
+                    with open(filepath, "r", encoding="utf-8" ) as fp:
+                        i, n = None, None
+                        for line in fp:
+                            line = line.strip()
 
-                        if line.startswith('"appid"'):
-                            i = line.replace('"appid"', "").strip()[1:-1]
-                        if line.startswith('"installdir"'):
-                            n = line.replace('"installdir"', "").strip()[1:-1]
+                            if line.startswith('"appid"'):
+                                i = line.replace('"appid"', "").strip()[1:-1]
+                            if line.startswith('"installdir"'):
+                                n = line.replace('"installdir"', "").strip()[1:-1]
 
-                        if i is not None and n is not None:
-                            break
-                if i is None or n is None:
-                    continue
-                self.games.append(SteamGame(i, n))
+                            if i is not None and n is not None:
+                                break
+                    if i is None or n is None:
+                        continue
+                    self.games.append(SteamGame(i, n))
+                except:
+                    qWarning("Unable to parse file \"{}\"".format(filepath.encode('utf-8')))
 
     def __repr__(self):
         return str(self)

--- a/steam_utils.py
+++ b/steam_utils.py
@@ -3,12 +3,11 @@
 # Code greatly inspired by https://github.com/LostDragonist/steam-library-setup-tool
 
 import os
+import sys
 import winreg  # type: ignore
 
 from pathlib import Path
 from typing import Dict
-
-from PyQt5.QtCore import qWarning
 
 
 class SteamGame:
@@ -32,7 +31,7 @@ class LibraryFolder:
             if filename.startswith("appmanifest"):
                 filepath = os.path.join(path, "steamapps", filename)
                 try:
-                    with open(filepath, "r", encoding="utf-8" ) as fp:
+                    with open(filepath, "r", encoding="utf-8") as fp:
                         i, n = None, None
                         for line in fp:
                             line = line.strip()
@@ -47,8 +46,8 @@ class LibraryFolder:
                     if i is None or n is None:
                         continue
                     self.games.append(SteamGame(i, n))
-                except:
-                    qWarning("Unable to parse file \"{}\"".format(filepath.encode('utf-8')))
+                except UnicodeDecodeError:
+                    print('Unable to parse file "{}"'.format(filepath), file=sys.stderr)
 
     def __repr__(self):
         return str(self)


### PR DESCRIPTION
Apparently Steam is known to corrupt its own appmanifest
files.  This will make the plugin skip any outright unreadable
files.

This is flagged WIP as I have done zero testing.  Haven't even launched MO with this file yet.