### PR TITLE
[STALKER Anomaly] Workaround for error when steam id isn't provided

### DIFF
--- a/games/game_stalkeranomaly.py
+++ b/games/game_stalkeranomaly.py
@@ -41,6 +41,8 @@ class StalkerAnomalyGame(BasicGame, mobase.IPluginFileMapper):
     GameBinary = "AnomalyLauncher.exe"
     GameDataPath = ""
 
+    GameSteamId = 0
+
     GameSaveExtension = "scop"
     GameSavesDirectory = "%GAME_PATH%/appdata/savedgames"
 


### PR DESCRIPTION
As Anomaly doesn't have a steam page, this is set to 0