### PR TITLE
No Man's Sky plugin - Added default flat & VR executables

### DIFF
--- a/games/game_nomanssky.py
+++ b/games/game_nomanssky.py
@@ -1,5 +1,9 @@
 # -*- encoding: utf-8 -*-
 
+from PyQt5.QtCore import QFileInfo
+
+import mobase
+
 from ..basic_game import BasicGame
 
 
@@ -17,3 +21,15 @@ class NoMansSkyGame(BasicGame):
     GameGogId = 1446213994
     GameBinary = "Binaries/NMS.exe"
     GameDataPath = "GAMEDATA/PCBANKS/MODS"
+
+    def executables(self):
+        return [
+            mobase.ExecutableInfo(
+                "No Man's Sky",
+                QFileInfo(self.gameDirectory().absoluteFilePath(self.binaryName())),
+            ),
+            mobase.ExecutableInfo(
+                "No Man's Sky VR",
+                QFileInfo(self.gameDirectory().absoluteFilePath(self.binaryName())),
+            ).withArgument("-HmdEnable 1"),
+        ]


### PR DESCRIPTION
Added override for the basic executables override to include a launch option for No Man's Sky in VR. Tested locally with Steam, NMS 3.21, and MO2 2.4.

**Note:** I'm new to all of this (git, python, MO2), so please feel free to push back and ask for changes/clarifications if I'm doing anything wrong. I'll try to keep the changes simple until I get my feet on solid ground.

![MO2 NMS Executables](https://user-images.githubusercontent.com/79597603/109248399-5559e600-77ab-11eb-920b-390066d3bc36.png)