### PR TITLE
Added basic Assetto Corsa, BeamNG.Drive, Beat Saber, MSFS2020, XP11 support

### DIFF
--- a/games/game_assettocorsa.py
+++ b/games/game_assettocorsa.py
@@ -1,0 +1,21 @@
+from ..basic_game import BasicGame
+from ..basic_features import BasicGameSaveGameInfo
+
+import mobase
+import os
+
+class AssettoCorsaGame(BasicGame):
+    Name = "Assetto Corsa Support Plugin"
+    Author = "Deorder"
+    Version = "0.0.1"
+
+    GameName = "Assetto Corsa"
+    GameShortName = "ac"
+    GameBinary = r"AssettoCorsa.exe"
+    GameDataPath = r""
+    GameSteamId = 244210
+    GameDocumentsDirectory = "%DOCUMENTS%/Assetto Corsa"
+
+    def init(self, organizer: mobase.IOrganizer):
+        super().init(organizer)
+        return True

--- a/games/game_beamng.py
+++ b/games/game_beamng.py
@@ -1,0 +1,17 @@
+from ..basic_game import BasicGame
+from ..basic_features import BasicGameSaveGameInfo
+
+import mobase
+import os
+
+class BeamNGGame(BasicGame):
+
+    Name = "BeamNG.drive Support Plugin"
+    Author = "Deorder"
+    Version = "0.0.1"
+
+    GameName = "BeamNG.drive"
+    GameShortName = "beamng"
+    GameBinary = r"Bin64\BeamNG.drive.x64.exe"
+    GameDataPath = r"%DOCUMENTS%\BeamNG.drive"
+    GameSteamId = [284160]

--- a/games/game_beatsaber.py
+++ b/games/game_beatsaber.py
@@ -1,0 +1,17 @@
+from ..basic_game import BasicGame
+from ..basic_features import BasicGameSaveGameInfo
+
+import mobase
+import os
+
+class BeatSaberGame(BasicGame):
+
+    Name = "Beat Saber Support Plugin"
+    Author = "Deorder"
+    Version = "0.0.1"
+
+    GameName = "Beat Saber"
+    GameShortName = "beatsaber"
+    GameBinary = r"Beat Saber.exe"
+    GameDataPath = r""
+    GameSteamId = [620980]

--- a/games/game_msfs2020.py
+++ b/games/game_msfs2020.py
@@ -1,0 +1,17 @@
+from ..basic_game import BasicGame
+from ..basic_features import BasicGameSaveGameInfo
+
+import mobase
+import os
+
+class MSFS2020Game(BasicGame):
+
+    Name = "Microsoft Flight Simulator 2020 Support Plugin"
+    Author = "Deorder"
+    Version = "0.0.1"
+
+    GameName = "Microsoft Flight Simulator 2020"
+    GameShortName = "msfs2020"
+    GameBinary = r"FlightSimulator.exe"
+    GameDataPath = r"%USERPROFILE%\AppData\Roaming\Microsoft Flight Simulator\Packages"
+    GameSteamId = [1250410]

--- a/games/game_xplane11.py
+++ b/games/game_xplane11.py
@@ -1,0 +1,16 @@
+from ..basic_game import BasicGame
+from ..basic_features import BasicGameSaveGameInfo
+
+import mobase
+import os
+
+class XP11Game(BasicGame):
+
+    Name = "X-Plane 11 Support Plugin"
+    Author = "Deorder"
+    Version = "0.0.1"
+
+    GameName = "X-Plane 11"
+    GameShortName = "xp11"
+    GameBinary = r"X-Plane.exe"
+    GameDataPath = r""


### PR DESCRIPTION
## Assetto Corsa (Tested)

Most AC mods use the game directory as their root. If not, create the parent folders yourself and move the directory in there during mod installation.
Instead of using the official Assetto Corsa executable consider using the Content Manager which can be downloaded / bought at: https://assettocorsa.club/content-manager.html
The Content Manager (which is then to be started via MO2) + the Custom Shader Patch will change Assetto Corsa in a modern and in my opinion one of the best racing games. The Content Manager does not have a good mod manager yet (Ilya is working on one), but meanwhile this will help you to install Assetto Corsa mods in a non-destructive way and keep track of versioning and add notes (download location etc.).
When using the Content Manager do not forget to install the track, car updates once in a while from inside the Custom Shader Patch and opening the '...' context menus. This will improve the tracks & cars by making them use the new features added by the Custom Shader Patch.

## Beam.NG Drive (Tested)

Many Beam.NG mods are to be installed inside the `<Documents>/BeamNG.drive/mods` folder. This will use Beam.NG's own mod system. Very often the official mod system is not good enough and other files outside of the `mods` folder require to be changed. MO2 will enable us to do this in a non-destructive way. If you want to install a mod that has to be installed inside the `mods` folder you can just create an new mod inside MO2, add a `mods` folder and move the zip file in there. MO2's overwrite feature will take care of any files generated by Beam.NG while keeping the original folders clean.

## Beat Saber (Experimental)

Most Beat Saber mods are to be installed relative to the game's root directory. There is also an semi-official mod manager called Mod Assistant, but I prefer to use MO2 and enjoy its benefits. You may want to run the IPA (injector) outside of MO2, but it should work from inside MO2 as well with the benefit that it will add all modified files to the overwrite folder, not touching the original folder.

## Microsoft Flight Simulator 2020 (Tested)

Microsoft Flight Simulator uses a `Packages` folder where all extra content of the game is installed. This custom game support plugin assumes that the packages are installed in `%USERPROFILE%\AppData\Roaming\Microsoft Flight Simulator\Packages`, which is the default location. If you chose a different location you can achieve the same effect by letting MSFS2020 use the default location again and then move the `Official` folder to its own mod by creating an new mod inside MO2 that you could call `Official Packages`. When you install a community package you will have to make sure they are placed relative to the `Community` folder, for example:

The official packages:
`<Mod Organizer Folder>\mods\Official Packages\Official\*`

An example community package:
`<Mod Organizer Folder>\mods\FlybyWireSim A32NX\Community\A32NX\*`

When MSFS2020 updates their official packages you may want to move the updated files from the `overwrite` folder to the `Official Packages` mod.

## X-Plane 11 (Tested)

Many X-Plane 11 modifications are to be installed relative to the game's root directory. By using MO2 we can install many of the mods that tend to overwite official files in an non-destructive way. Of course do not forget to update the official files once in a while by using the official launcher.
