### PR TITLE
Add basic Valkyria Chronicles support

### DIFF
--- a/games/game_valkyriachronicles.py
+++ b/games/game_valkyriachronicles.py
@@ -1,0 +1,15 @@
+from PyQt5.QtCore import QDir
+from ..basic_game import BasicGame
+
+class ValkyriaChroniclesGame(BasicGame):
+    Name = "Valkyria Chronicles Support Plugin"
+    Author = "Ketsuban"
+    Version = "1.0.0"
+
+    GameName = "Valkyria Chronicles"
+    GameShortName = "vc1"
+    GameBinary = "Valkyria.exe"
+    GameLauncher = "Launcher.exe"
+    GameDataPath = "%GAME_PATH%"
+    GameSavesDirectory = "%GAME_PATH%/savedata"
+    GameSteamId = 294860


### PR DESCRIPTION
I mostly just followed the instructions in the README.

While the DLCs have Steam IDs ([`314780`](https://steamdb.info/app/314780/), [`314781`](https://steamdb.info/app/314781/), [`314782`](https://steamdb.info/app/314782/) and [`314783`](https://steamdb.info/app/314783/)), I can't find any easy way of determining which folder corresponds to which DLC so MO2 currently doesn't list them in the mod list like it does for Skyrim. It'd be nice to get that working.

I didn't bother trying to parse anything from the save data - `playdata###.dat` starts with a mostly-ASCII string containing the date the save was made, the name of the chapter you're currently on, whether the save was made in book mode or campaign mode, and the time spent playing (three digits of hour, two digits of minute, padded with `0x81`). For example:
```
Play Data
27/12/2021 00:39

Prologue: Gallia, to Arms!
Book Mode
0hrs.0min.12sec.
```
This would make a nice addition.