### PR TITLE
Add basic_feature: BasicModDataChecker

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,9 @@ You can rename `modorganizer-basic_games-xxx` to whatever you want (e.g., `basic
 | S.T.A.L.K.E.R. Anomaly — [MOD](https://www.stalker-anomaly.com/) | [Qudix](https://github.com/Qudix) | [game_stalkeranomaly.py](games/game_stalkeranomaly.py) | <ul><li>mod data checker</li></ul> |
 | Stardew Valley — [GOG](https://www.gog.com/game/stardew_valley) / [STEAM](https://store.steampowered.com/app/413150/Stardew_Valley/) | [Syer10](https://github.com/Syer10), [Holt59](https://github.com/holt59/) | [game_stardewvalley.py](games/game_stardewvalley.py) | <ul><li>mod data checker</li></ul> |
 | STAR WARS™ Empire at War: Gold Pack - [GOG](https://www.gog.com/game/star_wars_empire_at_war_gold_pack) / [STEAM](https://store.steampowered.com/app/32470/) | [erri120](https://github.com/erri120) | <ul><li>Empire at War: [game_starwars-empire-at-war.py](games/game_starwars-empire-at-war.py)</li><li>Force of Corruption: [game_starwars-empire-at-war-foc.py](games/game_starwars-empire-at-war-foc.py)</li></ul> | |
-| Valheim — [STEAM](https://store.steampowered.com/app/892970/Valheim/) | [Zash](https://github.com/ZashIn) | [game_valheim.py](games/game_valheim.py) | <ul><li>mod data checker</li><li>overwrite config sync</li><li>save game support (no preview)</li></ul>
+| Subnautica — [STEAM](https://store.steampowered.com/app/264710/) | [dekart811](https://github.com/dekart811), [Zash](https://github.com/ZashIn) | [game_subnautica.py](games/game_subnautica.py) | <ul><li>mod data checker</li><li>save game preview</li></ul> |
+| Subnautica: Below Zero — [STEAM](https://store.steampowered.com/app/848450/) | [dekart811](https://github.com/dekart811), [Zash](https://github.com/ZashIn) | [game_subnautica-below-zero.py](games/game_subnautica-below-zero.py) | <ul><li>mod data checker</li><li>save game preview</li></ul> |
+| Valheim — [STEAM](https://store.steampowered.com/app/892970/Valheim/) | [Zash](https://github.com/ZashIn) | [game_valheim.py](games/game_valheim.py) | <ul><li>mod data checker</li><li>overwrite config sync</li><li>save game support (no preview)</li></ul> |
 | The Witcher: Enhanced Edition - [GOG](https://www.gog.com/game/the_witcher) / [STEAM](https://store.steampowered.com/app/20900/The_Witcher_Enhanced_Edition_Directors_Cut/) | [erri120](https://github.com/erri120) | [game_witcher1.py](games/game_witcher1.py) | <ul><li>save game parsing (no preview)</li></ul> |
 | The Witcher 3: Wild Hunt — [GOG](https://www.gog.com/game/the_witcher_3_wild_hunt) / [STEAM](https://store.steampowered.com/app/292030/The_Witcher_3_Wild_Hunt/) | [Holt59](https://github.com/holt59/) | [game_witcher3.py](games/game_witcher3.py) | <ul><li>save game preview</li></ul> |
 | Yu-Gi-Oh! Master Duel — [STEAM](https://store.steampowered.com/app/1449850/) | [The Conceptionist](https://github.com/the-conceptionist) & [uwx](https://github.com/uwx) | [game_masterduel.py](games/game_masterduel.py) | |
@@ -172,6 +174,10 @@ The meta-plugin provides some useful extra feature:
 2. **Basic save game preview:** If you use the Python version, and if you can easily obtain a picture (file)
   for any saves, you can provide basic save-game preview by using the `BasicGameSaveGameInfo`.
   See [games/game_witcher3.py](games/game_witcher3.py) for  more details.
+3. **Basic mod data checker** (Python):
+  Check and fix different mod archive layouts for an automatic installation with the proper
+  file structure, using simple (glob) patterns via `BasicModDataChecker`.
+  See [games/game_valheim.py](games/game_valheim.py) and [game_subnautica.py](games/game_subnautica.py) for an example.
 
 Game IDs can be found here:
 

--- a/basic_features/basic_mod_data_checker.py
+++ b/basic_features/basic_mod_data_checker.py
@@ -1,0 +1,177 @@
+# -*- encoding: utf-8 -*-
+from __future__ import annotations
+
+import fnmatch
+import re
+from collections.abc import Iterable, Sequence
+from dataclasses import dataclass, field, fields
+from typing import Optional
+
+
+import mobase
+
+
+def convert_entry_to_tree(entry: mobase.FileTreeEntry) -> Optional[mobase.IFileTree]:
+    if not entry.isDir():
+        return None
+    if isinstance(entry, mobase.IFileTree):
+        return entry
+    if (parent := entry.parent()) is None:
+        return None
+    converted_entry = parent.find(
+        entry.name(), mobase.FileTreeEntry.FileTypes.DIRECTORY
+    )
+    if isinstance(converted_entry, mobase.IFileTree):
+        return converted_entry
+    return None
+
+
+@dataclass
+class FileRegexPatterns:
+    """Regex pattern matching the file glob patterns in `FilePatterns`."""
+
+    set_as_root: Optional[re.Pattern] = None
+    valid: Optional[re.Pattern] = None
+    delete: Optional[re.Pattern] = None
+    move: Optional[re.Pattern] = None
+
+    @classmethod
+    def from_file_patterns(cls, file_patterns: FilePatterns) -> FileRegexPatterns:
+        """Returns an instance of `FileRegexPatterns`,
+        with the file list fields from `FilePatterns` as regex patterns.
+        """
+        return cls(
+            **{
+                f.name: (
+                    cls.file_glob_list_regex(value)
+                    if (value := getattr(file_patterns, f.name))
+                    else None
+                )
+                for f in fields(cls)
+            }
+        )
+
+    @staticmethod
+    def file_glob_list_regex(file_list: Iterable[str]) -> re.Pattern:
+        """Returns a regex pattern for a file list with glob patterns.
+
+        Every pattern has a capturing group,
+        so that `match.lastindex - 1` will give the `file_list` index.
+        """
+        return re.compile(
+            f'(?:{"|".join(f"({fnmatch.translate(f)})" for f in file_list)})', re.I
+        )
+
+
+@dataclass
+class FilePatterns:
+    """File (glob pattern) definitions for the `BasicGameModDataChecker`.
+    Match files / folders with e.g. `.regex.move.match`.
+    Fields match `.regex`.
+    """
+
+    set_as_root: Optional[Iterable[str]] = None
+    """If a folder from this set is found, it will be set as new root dir (unfolded) and
+    its contents checked again.
+    """
+
+    valid: Optional[Iterable[str]] = None
+    """Files and folders in the right path.
+    Check result: `mobase.ModDataChecker.VALID`.
+    """
+
+    delete: Optional[Iterable[str]] = None
+    """Files/folders to delete. Check result:: `mobase.ModDataChecker.FIXABLE`."""
+
+    move: Optional[dict[str, str]] = None
+    """Files/folders to move and their target.
+
+    If the path ends with `/` or `\\`, the entry will be inserted
+    in the corresponding directory instead of replacing it.
+
+    Check result: `mobase.ModDataChecker.FIXABLE`.
+
+    Example::
+
+        {"*.ext": "path/to/target_folder/"}
+
+    See Also:
+        `mobase.IFileTree.move`
+    """
+
+    regex: FileRegexPatterns = field(init=False)
+    """The regex patterns derived from the file (glob) patterns."""
+    _move_targets: Sequence[str] = field(init=False, repr=False)
+
+    def __post_init__(self):
+        self.update_regex()
+
+    def update_regex(self):
+        """Update regex after init field changes."""
+        self.regex = FileRegexPatterns.from_file_patterns(self)
+        if self.move:
+            self._move_targets = list(self.move.values())
+
+    def find_move_target(self, file_name: str) -> Optional[str]:
+        """Find a matching pattern (key) from `.move` and return its (value) matching the
+
+        Args:
+            match_index: Either the match from `.regex.move.match` or the index
+                of the move target = matched group index - 1.
+        """
+        if (
+            self.regex.move
+            and (match := self.regex.move.match(file_name))
+            and (i := match.lastindex) is not None
+        ):
+            return self._move_targets[i - 1]
+        return None
+
+
+class BasicModDataChecker(mobase.ModDataChecker):
+    """Game feature that is used to check and fix the content of a data tree
+    via simple files patterns.
+    """
+
+    file_patterns: FilePatterns
+
+    def __init__(self, file_patterns: FilePatterns):
+        super().__init__()
+        self.file_patterns = file_patterns
+
+    def dataLooksValid(
+        self, filetree: mobase.IFileTree
+    ) -> mobase.ModDataChecker.CheckReturn:
+        status = mobase.ModDataChecker.INVALID
+        for entry in filetree:
+            name = entry.name().casefold()
+            regex = self.file_patterns.regex
+            if regex.set_as_root and regex.set_as_root.match(name):
+                return mobase.ModDataChecker.FIXABLE
+            elif regex.valid and regex.valid.match(name):
+                if status is not mobase.ModDataChecker.FIXABLE:
+                    status = mobase.ModDataChecker.VALID
+            elif (regex.move and regex.move.match(name)) or (
+                regex.delete and regex.delete.match(name)
+            ):
+                status = mobase.ModDataChecker.FIXABLE
+            else:
+                return mobase.ModDataChecker.INVALID
+        return status
+
+    def fix(self, filetree: mobase.IFileTree) -> Optional[mobase.IFileTree]:
+        for entry in list(filetree):
+            name = entry.name().casefold()
+            regex = self.file_patterns.regex
+            if regex.set_as_root and regex.set_as_root.match(name):
+                new_root = convert_entry_to_tree(entry)
+                return self.fix(new_root) if new_root else None
+            elif regex.valid and regex.valid.match(name):
+                continue
+            elif regex.delete and regex.delete.match(name):
+                entry.detach()
+            elif regex.move:
+                move_target = self.file_patterns.find_move_target(name)
+                if move_target is not None:
+                    filetree.move(entry, move_target)
+        return filetree

--- a/basic_features/basic_mod_data_checker.py
+++ b/basic_features/basic_mod_data_checker.py
@@ -65,14 +65,16 @@ class FileRegexPatterns:
 
 @dataclass
 class FilePatterns:
-    """File (glob pattern) definitions for the `BasicGameModDataChecker`.
+    """File definitions for the `BasicGameModDataChecker`.
+    Glob pattern supported (without subfolders).
+
     Match files / folders with e.g. `.regex.move.match`.
     Fields match `.regex`.
     """
 
     set_as_root: Optional[Iterable[str]] = None
     """If a folder from this set is found, it will be set as new root dir (unfolded) and
-    its contents checked again.
+    its contents are checked again.
     """
 
     valid: Optional[Iterable[str]] = None
@@ -130,7 +132,7 @@ class FilePatterns:
 
 class BasicModDataChecker(mobase.ModDataChecker):
     """Game feature that is used to check and fix the content of a data tree
-    via simple files patterns.
+    via simple glob files patterns (without subfolders).
     """
 
     file_patterns: FilePatterns

--- a/games/game_subnautica-below-zero.py
+++ b/games/game_subnautica-below-zero.py
@@ -1,19 +1,69 @@
+from __future__ import annotations
+
+import dataclasses
+import os
+from pathlib import Path
+
+from PyQt5.QtCore import QDir
+
+import mobase
+
+from ..basic_features.basic_mod_data_checker import BasicModDataChecker
+from ..basic_features.basic_save_game_info import (
+    BasicGameSaveGame,
+    BasicGameSaveGameInfo,
+)
 from ..basic_game import BasicGame
+from .game_subnautica import subnautica_file_patterns
+
+subnautica_below_zero_file_patterns = dataclasses.replace(
+    subnautica_file_patterns, set_as_root={"BepInExPack_BelowZero"}
+)
 
 
 class SubnauticaGame(BasicGame):
 
     Name = "Subnautica Below Zero Support Plugin"
-    Author = "dekart811"
-    Version = "1.0"
+    Author = "dekart811, Zash"
+    Version = "2.0"
 
     GameName = "Subnautica: Below Zero"
     GameShortName = "subnauticabelowzero"
     GameNexusName = "subnauticabelowzero"
     GameSteamId = 848450
     GameBinary = "SubnauticaZero.exe"
-    GameDataPath = "QMods"
+    GameDataPath = ""
     GameDocumentsDirectory = "%GAME_PATH%"
+    GameSavesDirectory = r"%GAME_PATH%\SNAppData\SavedGames"
 
-    def iniFiles(self):
-        return ["doorstop_config.ini"]
+    _forced_libraries = ["winhttp.dll"]
+
+    def init(self, organizer: mobase.IOrganizer) -> bool:
+        super().init(organizer)
+        self._featureMap[mobase.ModDataChecker] = BasicModDataChecker(
+            subnautica_below_zero_file_patterns
+        )
+        self._featureMap[mobase.SaveGameInfo] = BasicGameSaveGameInfo(
+            lambda s: os.path.join(s, "screenshot.jpg")
+        )
+        return True
+
+    def listSaves(self, folder: QDir) -> list[mobase.ISaveGame]:
+        savegames = super().listSaves(folder)
+        for save_path in [
+            folder.absolutePath(),
+            os.path.expandvars(
+                r"%USERPROFILE%\Appdata\LocalLow\Unknown Worlds"
+                r"\Subnautica Below Zero\SubnauticaZero\SavedGames"
+            ),
+        ]:
+            savegames.extend(
+                BasicGameSaveGame(folder) for folder in Path(save_path).glob("slot*")
+            )
+        return savegames
+
+    def executableForcedLoads(self) -> list[mobase.ExecutableForcedLoadSetting]:
+        return [
+            mobase.ExecutableForcedLoadSetting(self.binaryName(), lib).withEnabled(True)
+            for lib in self._forced_libraries
+        ]

--- a/games/game_subnautica.py
+++ b/games/game_subnautica.py
@@ -1,8 +1,17 @@
 from __future__ import annotations
 
+import os
+from pathlib import Path
+
+from PyQt5.QtCore import QDir
+
 import mobase
 
 from ..basic_features.basic_mod_data_checker import BasicModDataChecker, FilePatterns
+from ..basic_features.basic_save_game_info import (
+    BasicGameSaveGame,
+    BasicGameSaveGameInfo,
+)
 from ..basic_game import BasicGame
 
 subnautica_file_patterns = FilePatterns(
@@ -41,7 +50,24 @@ class SubnauticaGame(BasicGame):
         self._featureMap[mobase.ModDataChecker] = BasicModDataChecker(
             subnautica_file_patterns
         )
+        self._featureMap[mobase.SaveGameInfo] = BasicGameSaveGameInfo(
+            lambda s: os.path.join(s, "screenshot.jpg")
+        )
         return True
+
+    def listSaves(self, folder: QDir) -> list[mobase.ISaveGame]:
+        savegames = super().listSaves(folder)
+        for save_path in [
+            folder.absolutePath(),
+            os.path.expandvars(
+                r"%USERPROFILE%\Appdata\LocalLow\Unknown Worlds"
+                r"\Subnautica\Subnautica\SavedGames"
+            ),
+        ]:
+            savegames.extend(
+                BasicGameSaveGame(folder) for folder in Path(save_path).glob("slot*")
+            )
+        return savegames
 
     def executableForcedLoads(self) -> list[mobase.ExecutableForcedLoadSetting]:
         return [

--- a/games/game_subnautica.py
+++ b/games/game_subnautica.py
@@ -1,19 +1,50 @@
+from __future__ import annotations
+
+import mobase
+
+from ..basic_features.basic_mod_data_checker import BasicModDataChecker, FilePatterns
 from ..basic_game import BasicGame
+
+subnautica_file_patterns = FilePatterns(
+    set_as_root={"BepInExPack_Subnautica"},
+    valid={"winhttp.dll", "doorstop_config.ini", "BepInEx", "QMods"},
+    delete={
+        "*.txt",
+        "*.md",
+        "icon.png",
+        "license",
+        "manifest.json",
+    },
+    move={"plugins": "BepInEx/", "patchers": "BepInEx/", "*": "QMods/"},
+)
 
 
 class SubnauticaGame(BasicGame):
 
     Name = "Subnautica Support Plugin"
-    Author = "dekart811"
-    Version = "1.0"
+    Author = "dekart811, Zash"
+    Version = "2.0"
 
     GameName = "Subnautica"
     GameShortName = "subnautica"
     GameNexusName = "subnautica"
     GameSteamId = 264710
     GameBinary = "Subnautica.exe"
-    GameDataPath = "QMods"
-    GameDocumentsDirectory = "%GAME_PATH%"
+    GameDataPath = ""
+    GameDocumentsDirectory = r"%GAME_PATH%"
+    GameSavesDirectory = r"%GAME_PATH%\SNAppData\SavedGames"
 
-    def iniFiles(self):
-        return ["doorstop_config.ini"]
+    _forced_libraries = ["winhttp.dll"]
+
+    def init(self, organizer: mobase.IOrganizer) -> bool:
+        super().init(organizer)
+        self._featureMap[mobase.ModDataChecker] = BasicModDataChecker(
+            subnautica_file_patterns
+        )
+        return True
+
+    def executableForcedLoads(self) -> list[mobase.ExecutableForcedLoadSetting]:
+        return [
+            mobase.ExecutableForcedLoadSetting(self.binaryName(), lib).withEnabled(True)
+            for lib in self._forced_libraries
+        ]

--- a/games/game_valheim.py
+++ b/games/game_valheim.py
@@ -548,6 +548,8 @@ class ValheimGame(BasicGame):
             self._sync_overwrite()
 
     def _sync_overwrite(self) -> None:
+        if self._organizer.managedGame() is not self:
+            return
         if self._organizer.pluginSetting(self.name(), "sync_overwrite") is not False:
             self._overwrite_sync.search_file_contents = (
                 self._organizer.pluginSetting(

--- a/games/game_valheim.py
+++ b/games/game_valheim.py
@@ -2,12 +2,11 @@
 
 from __future__ import annotations
 
-import fnmatch
 import itertools
 import re
 import shutil
 from collections.abc import Collection, Container, Iterable, Mapping, Sequence
-from dataclasses import dataclass, field, fields
+from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Optional, TextIO, Union
 
@@ -15,23 +14,9 @@ from PyQt5.QtCore import QDir
 
 import mobase
 
+from ..basic_features.basic_mod_data_checker import BasicModDataChecker, FilePatterns
 from ..basic_features.basic_save_game_info import BasicGameSaveGame
 from ..basic_game import BasicGame
-
-
-def convert_entry_to_tree(entry: mobase.FileTreeEntry) -> Optional[mobase.IFileTree]:
-    if not entry.isDir():
-        return None
-    if isinstance(entry, mobase.IFileTree):
-        return entry
-    if (parent := entry.parent()) is None:
-        return None
-    converted_entry = parent.find(
-        entry.name(), mobase.FileTreeEntry.FileTypes.DIRECTORY
-    )
-    if isinstance(converted_entry, mobase.IFileTree):
-        return converted_entry
-    return None
 
 
 def move_file(source: Path, target: Path):
@@ -130,7 +115,8 @@ class DebugTable:
         if self._table:
             for line in self._table:
                 print("|", " | ".join(line.values()), "|", file=output_file)
-            output_file and output_file.flush()
+            if output_file:
+                output_file.flush()
             self._table = []
 
 
@@ -277,165 +263,6 @@ class OverwriteSync:
         )
 
 
-@dataclass
-class RegexFilesDefinition:
-    """Regex pattern for the file lists in `FilesDefinition` - for globbing support.
-    Fields should match `RegexFilesDefinition`.
-    """
-
-    set_as_root: Optional[re.Pattern]
-    valid: Optional[re.Pattern]
-    delete: Optional[re.Pattern]
-    move: Optional[re.Pattern]
-
-    @classmethod
-    def from_filesmap(cls, filesdef: FilesDefinition) -> RegexFilesDefinition:
-        """Returns an instance of `RegexFilesDefinition`,
-        with the file list fields from `FilesDefinition` as regex patterns.
-        """
-        return cls(
-            **{
-                f.name: (
-                    cls.file_list_regex(value)
-                    if (value := getattr(filesdef, f.name))
-                    else None
-                )
-                for f in fields(cls)
-            }
-        )
-
-    @staticmethod
-    def file_list_regex(file_list: Iterable[str]) -> re.Pattern:
-        """Returns a regex pattern for a file list with glob patterns.
-
-        Every pattern has a capturing group,
-        so that match.lastindex - 1 will give the file_list index.
-        """
-        return re.compile(
-            f'(?:{"|".join(f"({fnmatch.translate(f)})" for f in file_list)})', re.I
-        )
-
-
-@dataclass
-class FilesDefinition:
-    """File (pattern) definitions for the `mobase.ModDataChecker`.
-    Fields should match `RegexFilesDefinition`.
-    """
-
-    set_as_root: Optional[set[str]]
-    """If a folder from this set is found, it will be set as new root dir (unfolded)."""
-    valid: Optional[set[str]]
-    """Files and folders in the right path."""
-    delete: Optional[set[str]]
-    """Files/folders to delete."""
-    move: Optional[dict[str, str]]
-    """Files/folders to move, like `{"*.ext": "path/to/folder/"}`.
-        If the path ends with / or \\, the entry will be inserted
-        in the corresponding directory instead of replacing it.
-    """
-
-    regex: RegexFilesDefinition = field(init=False)
-    _move_targets: Sequence[str] = field(init=False, repr=False)
-
-    def __post_init__(self):
-        self.regex = RegexFilesDefinition.from_filesmap(self)
-        if self.move:
-            self._move_targets = list(self.move.values())
-
-    def get_move_target(self, index: int) -> str:
-        return self._move_targets[index]
-
-
-class ValheimGameModDataChecker(mobase.ModDataChecker):
-    files_map = FilesDefinition(
-        set_as_root={
-            "BepInExPack_Valheim",
-        },
-        valid={
-            "meta.ini",  # Included in installed mod folder.
-            "BepInEx",
-            "doorstop_libs",
-            "unstripped_corlib",
-            "doorstop_config.ini",
-            "start_game_bepinex.sh",
-            "start_server_bepinex.sh",
-            "winhttp.dll",
-            #
-            "InSlimVML",
-            "valheim_Data",
-            "inslimvml.ini",
-            #
-            "unstripped_managed",
-            #
-            "AdvancedBuilder",
-        },
-        delete={
-            "*.txt",
-            "*.md",
-            "icon.png",
-            "license",
-            "manifest.json",
-        },
-        move={
-            "*_VML.dll": "InSlimVML/Mods/",
-            #
-            "plugins": "BepInEx/",
-            "*.dll": "BepInEx/plugins/",
-            "config": "BepInEx/",
-            "*.cfg": "BepInEx/config/",
-            #
-            "CustomTextures": "BepInEx/plugins/",
-            "*.png": "BepInEx/plugins/CustomTextures/",
-            #
-            "Builds": "AdvancedBuilder/",
-            "*.vbuild": "AdvancedBuilder/Builds/",
-            #
-            "*.assets": "valheim_Data/",
-        },
-    )
-
-    def dataLooksValid(
-        self, filetree: mobase.IFileTree
-    ) -> mobase.ModDataChecker.CheckReturn:
-        status = mobase.ModDataChecker.INVALID
-        for entry in filetree:
-            name = entry.name().casefold()
-            regex = self.files_map.regex
-            if regex.set_as_root and regex.set_as_root.match(name):
-                return mobase.ModDataChecker.FIXABLE
-            elif regex.valid and regex.valid.match(name):
-                if status is not mobase.ModDataChecker.FIXABLE:
-                    status = mobase.ModDataChecker.VALID
-            elif (regex.move and regex.move.match(name)) or (
-                regex.delete and regex.delete.match(name)
-            ):
-                status = mobase.ModDataChecker.FIXABLE
-            else:
-                return mobase.ModDataChecker.INVALID
-        return status
-
-    def fix(self, filetree: mobase.IFileTree) -> Optional[mobase.IFileTree]:
-        for entry in list(filetree):
-            name = entry.name().casefold()
-            regex = self.files_map.regex
-            if regex.set_as_root and regex.set_as_root.match(name):
-                new_root = convert_entry_to_tree(entry)
-                return self.fix(new_root) if new_root else None
-            elif regex.valid and regex.valid.match(name):
-                continue
-            elif regex.delete and regex.delete.match(name):
-                entry.detach()
-            elif regex.move and (match := regex.move.match(name)):
-                if match.lastindex is None:
-                    return None
-                else:
-                    # Get index of matched group
-                    map_index = match.lastindex - 1
-                    # Get the move target corresponding to the matched group
-                    filetree.move(entry, self.files_map.get_move_target(map_index))
-        return filetree
-
-
 class ValheimSaveGame(BasicGameSaveGame):
     def getName(self) -> str:
         return f"[{self.getSaveGroupIdentifier().rstrip('s')}] {self._filepath.stem}"
@@ -485,7 +312,7 @@ class ValheimGame(BasicGame):
 
     Name = "Valheim Support Plugin"
     Author = "Zash"
-    Version = "1.1.1"
+    Version = "1.2"
 
     GameName = "Valheim"
     GameShortName = "valheim"
@@ -495,11 +322,58 @@ class ValheimGame(BasicGame):
     GameDataPath = ""
     GameSavesDirectory = r"%USERPROFILE%/AppData/LocalLow/IronGate/Valheim"
 
-    forced_libraries = ["winhttp.dll"]
+    _forced_libraries = ["winhttp.dll"]
 
     def init(self, organizer: mobase.IOrganizer) -> bool:
         super().init(organizer)
-        self._featureMap[mobase.ModDataChecker] = ValheimGameModDataChecker()
+        self._featureMap[mobase.ModDataChecker] = BasicModDataChecker(
+            FilePatterns(
+                set_as_root={
+                    "BepInExPack_Valheim",
+                },
+                valid={
+                    "meta.ini",  # Included in installed mod folder.
+                    "BepInEx",
+                    "doorstop_libs",
+                    "unstripped_corlib",
+                    "doorstop_config.ini",
+                    "start_game_bepinex.sh",
+                    "start_server_bepinex.sh",
+                    "winhttp.dll",
+                    #
+                    "InSlimVML",
+                    "valheim_Data",
+                    "inslimvml.ini",
+                    #
+                    "unstripped_managed",
+                    #
+                    "AdvancedBuilder",
+                },
+                delete={
+                    "*.txt",
+                    "*.md",
+                    "icon.png",
+                    "license",
+                    "manifest.json",
+                },
+                move={
+                    "*_VML.dll": "InSlimVML/Mods/",
+                    #
+                    "plugins": "BepInEx/",
+                    "*.dll": "BepInEx/plugins/",
+                    "config": "BepInEx/",
+                    "*.cfg": "BepInEx/config/",
+                    #
+                    "CustomTextures": "BepInEx/plugins/",
+                    "*.png": "BepInEx/plugins/CustomTextures/",
+                    #
+                    "Builds": "AdvancedBuilder/",
+                    "*.vbuild": "AdvancedBuilder/Builds/",
+                    #
+                    "*.assets": "valheim_Data/",
+                },
+            )
+        )
         self._featureMap[mobase.LocalSavegames] = ValheimLocalSavegames(
             self.savesDirectory()
         )
@@ -510,7 +384,7 @@ class ValheimGame(BasicGame):
     def executableForcedLoads(self) -> list[mobase.ExecutableForcedLoadSetting]:
         return [
             mobase.ExecutableForcedLoadSetting(self.binaryName(), lib).withEnabled(True)
-            for lib in self.forced_libraries
+            for lib in self._forced_libraries
         ]
 
     def listSaves(self, folder: QDir) -> list[mobase.ISaveGame]:


### PR DESCRIPTION
Generalization for the pattern matching from Valheim.

Added:
- New `basic_feature`: `class BasicModDataChecker(ModDataChecker)`
  A ModDataChecker via simple glob file patterns (no subfolders support).
  
  Example:
  ```py
  BasicModDataChecker(
      valid={"ModFolder"},
      delete={"*.md"},
      move={"*.ext": "ModFolder/"}
  )
  ```
  - accepts "ModFolder" (`ModDataChecker.VALID`)
  - removes "*.md" files (`FIXABLE`)
  - moves "*.ext" files to "ModFolder/*.ext"
 
- Subnautica: mod data checker, sage game preview
- Subnautica Below Zero: same

Closes:
- ModOrganizer2/modorganizer#1548
- ModOrganizer2/modorganizer#1549
