### PR TITLE
Reuse save games code from DAO to get this working

### DIFF
--- a/games/game_da2.py
+++ b/games/game_da2.py
@@ -1,7 +1,9 @@
-from PyQt5.QtCore import QDir
-from ..basic_game import BasicGame
+import os
 
 import mobase
+
+from ..basic_features import BasicGameSaveGameInfo
+from ..basic_game import BasicGame
 
 
 class DA2Game(BasicGame):
@@ -13,6 +15,7 @@ class DA2Game(BasicGame):
     GameShortName = "dragonage2"
     GameBinary = r"bin_ship\DragonAge2.exe"
     GameDataPath = r"%DOCUMENTS%\BioWare\Dragon Age 2\packages\core\override"
+    GameSavesDirectory = r"%DOCUMENTS%\BioWare\Dragon Age 2\Characters"
     GameSaveExtension = "das"
     GameSteamId = 1238040
     GameOriginManifestIds = ["OFB-EAST:59474", "DR:201797000"]
@@ -20,7 +23,11 @@ class DA2Game(BasicGame):
 
     def version(self):
         # Don't forget to import mobase!
-        return mobase.VersionInfo(1, 0, 0, mobase.ReleaseType.final)
+        return mobase.VersionInfo(1, 0, 1, mobase.ReleaseType.final)
 
-    def savesDirectory(self):
-        return QDir(self.documentsDirectory().absoluteFilePath("gamesaves"))
+    def init(self, organizer: mobase.IOrganizer):
+        super().init(organizer)
+        self._featureMap[mobase.SaveGameInfo] = BasicGameSaveGameInfo(
+            lambda s: os.path.split(s)[0] + "/screen.dds"
+        )
+        return True


### PR DESCRIPTION
Looks like the original plugin used example code. The save games for DA2 are largely the same as DAO. This allows them to show up in my MO2 environment at least.