### PR TITLE
Fix for 00000000

### DIFF
--- a/games/game_masterduel.py
+++ b/games/game_masterduel.py
@@ -57,8 +57,9 @@ class MasterDuelGame(BasicGame, mobase.IPluginFileMapper):
         subdirs = dir.entryList(
             filters=cast(QDir.Filters, QDir.Dirs | QDir.NoDotAndDotDot)
         )
+        list.reverse(subdirs)
         dir.cd(subdirs[0])
-
+        
         self._userDataDirCached = dir.absolutePath()
         return self._userDataDirCached
 


### PR DESCRIPTION
When starting Master Duel without having steam open it automatically creates a new folder in LocalData called 00000000, rendering all mods useless since they are put in that new 00000000 folder. Reversing the list fixes this issue as 00000000 will always be the last entry in the list, thereby getting ignored by dir.cd(subdirs[0]) in line 61.