### PR TITLE
Add Monster Hunter: Rise support

### DIFF
--- a/games/game_monsterhunterrise.py
+++ b/games/game_monsterhunterrise.py
@@ -1,0 +1,15 @@
+from ..basic_game import BasicGame
+
+
+class MonsterHunterRiseGame(BasicGame):
+    Name = "Monster Hunter: Rise Support Plugin"
+    Author = "RodolfoFigueroa"
+    Version = "1.0.0"
+
+    GameName = "Monster Hunter: Rise"
+    GameShortName = "monsterhunterrise"
+    GameBinary = "MonsterHunterRise.exe"
+    GameDataPath = "%GAME_PATH%"
+    GameSaveExtension = "bin"
+    GameNexusId = 848
+    GameSteamId = 1446780

--- a/games/game_monsterhunterrise.py
+++ b/games/game_monsterhunterrise.py
@@ -11,5 +11,5 @@ class MonsterHunterRiseGame(BasicGame):
     GameBinary = "MonsterHunterRise.exe"
     GameDataPath = "%GAME_PATH%"
     GameSaveExtension = "bin"
-    GameNexusId = 848
+    GameNexusId = 4095
     GameSteamId = 1446780


### PR DESCRIPTION
Basic Monster Hunter: Rise support. Requires [FirstNatives](https://www.nexusmods.com/monsterhunterrise/mods/848) for mods to work.