### PR TITLE
Cyberpunk full support

### DIFF
--- a/games/game_cyberpunk2077.py
+++ b/games/game_cyberpunk2077.py
@@ -3,15 +3,16 @@ from ..basic_game import BasicGame
 
 class Cyberpunk2077Game(BasicGame):
     Name = "Cyberpunk 2077 Support Plugin"
-    Author = "6788"
-    Version = "1.0.0"
+    Author = "6788, Zash"
+    Version = "1.1.0"
 
     GameName = "Cyberpunk 2077"
     GameShortName = "cyberpunk2077"
     GameBinary = "bin/x64/Cyberpunk2077.exe"
     GameLauncher = "REDprelauncher.exe"
     GameDataPath = "%GAME_PATH%"
-    GameDocumentsDirectory = "%USERPROFILE%/Saved Games/CD Projekt Red/Cyberpunk 2077"
+    GameDocumentsDirectory = "%USERPROFILE%/AppData/Local/CD Projekt Red/Cyberpunk 2077"
+    GameSavesDirectory = "%USERPROFILE%/Saved Games/CD Projekt Red/Cyberpunk 2077"
     GameSaveExtension = "dat"
     GameSteamId = 1091500
     GameGogId = 1423049311
@@ -19,3 +20,6 @@ class Cyberpunk2077Game(BasicGame):
         r"https://github.com/ModOrganizer2/modorganizer-basic_games/wiki/"
         "Game:-Cyberpunk-2077"
     )
+
+    def iniFiles(self):
+        return ["UserSettings.json"]

--- a/games/game_cyberpunk2077.py
+++ b/games/game_cyberpunk2077.py
@@ -1,10 +1,31 @@
+from pathlib import Path
+
+import mobase
+from PyQt6.QtCore import QDir
+
+from ..basic_features.basic_save_game_info import BasicGameSaveGame
 from ..basic_game import BasicGame
+
+
+class CyberpunkSaveGame(BasicGameSaveGame):
+    _name_file = "NamedSave.txt"  # from mod: Named Saves
+
+    def __init__(self, filepath: Path):
+        super().__init__(filepath)
+        try:  # Custom name from Named Saves
+            with open(filepath / self._name_file) as file:
+                self._name = file.readline()
+        except FileNotFoundError:
+            self._name = ""
+
+    def getName(self) -> str:
+        return self._name or super().getName()
 
 
 class Cyberpunk2077Game(BasicGame):
     Name = "Cyberpunk 2077 Support Plugin"
     Author = "6788, Zash"
-    Version = "1.1.0"
+    Version = "1.2.0"
 
     GameName = "Cyberpunk 2077"
     GameShortName = "cyberpunk2077"
@@ -23,3 +44,10 @@ class Cyberpunk2077Game(BasicGame):
 
     def iniFiles(self):
         return ["UserSettings.json"]
+
+    def listSaves(self, folder: QDir) -> list[mobase.ISaveGame]:
+        ext = self._mappings.savegameExtension.get()
+        return [
+            CyberpunkSaveGame(path.parent)
+            for path in Path(folder.absolutePath()).glob(f"**/*.{ext}")
+        ]

--- a/games/game_cyberpunk2077.py
+++ b/games/game_cyberpunk2077.py
@@ -3,6 +3,7 @@ from pathlib import Path
 import mobase
 from PyQt6.QtCore import QDir
 
+from ..basic_features import BasicLocalSavegames
 from ..basic_features.basic_save_game_info import BasicGameSaveGame
 from ..basic_game import BasicGame
 
@@ -25,7 +26,7 @@ class CyberpunkSaveGame(BasicGameSaveGame):
 class Cyberpunk2077Game(BasicGame):
     Name = "Cyberpunk 2077 Support Plugin"
     Author = "6788, Zash"
-    Version = "1.2.0"
+    Version = "1.3.0"
 
     GameName = "Cyberpunk 2077"
     GameShortName = "cyberpunk2077"
@@ -42,8 +43,12 @@ class Cyberpunk2077Game(BasicGame):
         "Game:-Cyberpunk-2077"
     )
 
-    def iniFiles(self):
-        return ["UserSettings.json"]
+    def init(self, organizer: mobase.IOrganizer) -> bool:
+        super().init(organizer)
+        self._featureMap[mobase.LocalSavegames] = BasicLocalSavegames(
+            self.savesDirectory()
+        )
+        return True
 
     def listSaves(self, folder: QDir) -> list[mobase.ISaveGame]:
         ext = self._mappings.savegameExtension.get()
@@ -51,3 +56,6 @@ class Cyberpunk2077Game(BasicGame):
             CyberpunkSaveGame(path.parent)
             for path in Path(folder.absolutePath()).glob(f"**/*.{ext}")
         ]
+
+    def iniFiles(self):
+        return ["UserSettings.json"]

--- a/games/game_cyberpunk2077.py
+++ b/games/game_cyberpunk2077.py
@@ -196,7 +196,7 @@ class CyberpunkSaveGame(BasicGameSaveGame):
 class Cyberpunk2077Game(BasicGame):
     Name = "Cyberpunk 2077 Support Plugin"
     Author = "6788, Zash"
-    Version = "1.4.0"
+    Version = "2.0.0"
 
     GameName = "Cyberpunk 2077"
     GameShortName = "cyberpunk2077"

--- a/games/game_cyberpunk2077.py
+++ b/games/game_cyberpunk2077.py
@@ -1,16 +1,150 @@
 import json
+import re
 from pathlib import Path
 
 import mobase
 from PyQt6.QtCore import QDir
 
-from ..basic_features import BasicLocalSavegames
+from ..basic_features import BasicLocalSavegames, BasicModDataChecker, GlobPatterns
 from ..basic_features.basic_save_game_info import (
     BasicGameSaveGame,
     BasicGameSaveGameInfo,
     format_date,
 )
+from ..basic_features.utils import is_directory
 from ..basic_game import BasicGame
+
+
+class CyberpunkModDataChecker(BasicModDataChecker):
+    def __init__(self):
+        super().__init__(
+            GlobPatterns(
+                valid=[
+                    "archive",
+                    # redscript
+                    "engine",
+                    "r6",
+                    "mods",  # RedMod
+                    "red4ext",  # red4ext/RED4ext.dll is moved to root in .fix()
+                    "bin",  # CET etc. gets handled below
+                    "root",  # RootBuilder: hardlink / copy to game root
+                ],
+                move={
+                    # archive and ArchiveXL
+                    "*.archive": "archive/pc/mod/",
+                    "*.xl": "archive/pc/mod/",
+                },
+            )
+        )
+
+    _extra_files_to_move = {
+        # Red4ext: only .dll files
+        "red4ext/RED4ext.dll": "root/red4ext/",
+        "bin/x64/winmm.dll": "root/bin/x64/",
+        # CET: all files, folder gets handled in .fix()
+        "bin/x64/version.dll": "root/bin/x64/",
+        "bin/x64/global.ini": "root/bin/x64/",
+        "bin/x64/plugins/cyber_engine_tweaks.asi": "root/bin/x64/plugins/",
+    }
+    """Some frameworks need to be copied or hard linked to root. Use / as sep!"""
+    _ignore_pattern = re.compile(r"licenses?$", re.I)
+
+    _cet_path = "bin/x64/plugins/cyber_engine_tweaks/"
+
+    def dataLooksValid(
+        self, filetree: mobase.IFileTree
+    ) -> mobase.ModDataChecker.CheckReturn:
+        # fix: single root folders get traversed by Simple Installer
+        parent = filetree.parent()
+        if parent is not None and self.dataLooksValid(parent) is self.FIXABLE:
+            return self.FIXABLE
+        if (status := super().dataLooksValid(filetree)) is not self.INVALID:
+            match self._check_bin_folder(filetree):
+                case self.INVALID:
+                    return self.INVALID
+                case self.FIXABLE:
+                    status = self.FIXABLE
+                case _:
+                    pass  # valid = keep status
+            # Check extra fixes
+            if any(filetree.exists(p) for p in self._extra_files_to_move):
+                status = self.FIXABLE
+        return status
+
+    def _check_bin_folder(
+        self, filetree: mobase.IFileTree
+    ) -> mobase.ModDataChecker.CheckReturn:
+        """Only Red4ext and CET are supported in bin folder."""
+        bin_folder = filetree.find("bin/x64")
+        if not bin_folder:
+            return self.VALID
+        elif not is_directory(bin_folder):
+            return self.INVALID
+        status = self.VALID
+        cet_path = self._cet_path.rstrip("/\\")
+        for entry in bin_folder:
+            entry_name = entry.name()
+            if self._ignore_pattern.match(entry_name):
+                continue
+            elif f"bin/x64/{entry_name}" in self._extra_files_to_move:
+                status = self.FIXABLE
+            elif entry_name == "plugins" and is_directory(entry):
+                for plugin in entry:
+                    plugin_path = f"bin/x64/plugins/{plugin.name()}"
+                    if plugin_path == cet_path:
+                        if not is_directory(plugin):
+                            return self.INVALID
+                        if not (len(plugin) == 1 and plugin.exists("mods")):
+                            status = self.FIXABLE  # CET framework: fix
+                    elif plugin_path in self._extra_files_to_move:
+                        status = self.FIXABLE
+                    else:
+                        return self.INVALID  # unknown plugin
+            else:
+                return self.INVALID  # unknown entry
+        return status
+
+    def fix(self, filetree: mobase.IFileTree) -> mobase.IFileTree:
+        if filetree := super().fix(filetree):
+            for source, target in self._extra_files_to_move.items():
+                if file := filetree.find(source):
+                    parent = file.parent()
+                    filetree.move(file, target)
+                    clear_empty_folder(parent)
+            self._fix_cet_framework(filetree)
+        return filetree
+
+    def _fix_cet_framework(self, filetree: mobase.IFileTree):
+        """Move CET framework to `root/`, except for `mods`.
+        Only CET >= v1.27.0 (Patch 2.01) works with USVFS.
+
+        See: https://github.com/maximegmd/CyberEngineTweaks/pull/877
+        """
+        if cet_folder := filetree.find(
+            self._cet_path, mobase.FileTreeEntry.FileTypes.DIRECTORY
+        ):
+            assert is_directory(cet_folder)
+            root_cet_path = f"root/{self._cet_path}"
+            if not cet_folder.exists("mods"):
+                parent = cet_folder.parent()
+                filetree.move(cet_folder, root_cet_path.rstrip("/\\"))
+            else:
+                parent = cet_folder
+                for entry in list(cet_folder):
+                    if entry.name() != "mods":
+                        filetree.move(entry, root_cet_path)
+            clear_empty_folder(parent)
+
+
+def clear_empty_folder(filetree: mobase.IFileTree | None):
+    if filetree is None:
+        return
+    while not filetree:
+        parent = filetree.parent()
+        filetree.detach()
+        if parent is None:
+            break
+        filetree = parent
 
 
 def time_from_seconds(s: int | float) -> str:
@@ -21,7 +155,6 @@ def time_from_seconds(s: int | float) -> str:
 
 def parse_cyberpunk_save_metadata(save_path: Path, save: mobase.ISaveGame):
     metadata_file = save_path / "metadata.9.json"
-
     try:
         with open(metadata_file) as file:
             meta_data = json.load(file)["Data"]["metadata"]
@@ -88,6 +221,7 @@ class Cyberpunk2077Game(BasicGame):
             lambda p: Path(p or "", "screenshot.png"),
             parse_cyberpunk_save_metadata,
         )
+        self._featureMap[mobase.ModDataChecker] = CyberpunkModDataChecker()
         return True
 
     def listSaves(self, folder: QDir) -> list[mobase.ISaveGame]:

--- a/games/game_cyberpunk2077.py
+++ b/games/game_cyberpunk2077.py
@@ -4,7 +4,7 @@ import shutil
 from pathlib import Path
 
 import mobase
-from PyQt6.QtCore import QDir
+from PyQt6.QtCore import QDateTime, QDir, qInfo
 
 from ..basic_features import BasicLocalSavegames, BasicModDataChecker, GlobPatterns
 from ..basic_features.basic_save_game_info import (
@@ -191,6 +191,11 @@ class CyberpunkSaveGame(BasicGameSaveGame):
 
     def getName(self) -> str:
         return self._name or super().getName()
+
+    def getCreationTime(self) -> QDateTime:
+        return QDateTime.fromSecsSinceEpoch(
+            int((self._filepath / "sav.dat").stat().st_mtime)
+        )
 
 
 class Cyberpunk2077Game(BasicGame):

--- a/games/game_cyberpunk2077.py
+++ b/games/game_cyberpunk2077.py
@@ -282,7 +282,7 @@ class ModListFileManager(dict[_MOD_TYPE, ModListFile]):
 class Cyberpunk2077Game(BasicGame):
     Name = "Cyberpunk 2077 Support Plugin"
     Author = "6788, Zash"
-    Version = "2.0.0"
+    Version = "2.1.0"
 
     GameName = "Cyberpunk 2077"
     GameShortName = "cyberpunk2077"

--- a/games/game_cyberpunk2077.py
+++ b/games/game_cyberpunk2077.py
@@ -237,6 +237,15 @@ class Cyberpunk2077Game(BasicGame):
     def iniFiles(self):
         return ["UserSettings.json"]
 
+    def executables(self) -> list[mobase.ExecutableInfo]:
+        return [
+            # Start without REDmod launcher
+            mobase.ExecutableInfo(
+                title=self.gameName(),
+                binary=self.gameDirectory().absoluteFilePath(self.binaryName()),
+            ).withArgument("--launcher-skip -skipStartScreen")
+        ]
+
     def _onAboutToRun(self, app_path: str, wd: QDir, args: str) -> bool:
         """
         Copy cache files (`final.redscript` etc.) to overwrite to catch


### PR DESCRIPTION
Current state and workarounds (to be integrated) are described in the [wiki page for Cyberpunk 2077](/ModOrganizer2/modorganizer-basic_games/wiki/Game:-Cyberpunk-2077)

## Features
Implemented features in this plugin update
- [x] profile specific config (`.ini`)
- [x] profile specific savegames, based on #122
- [x] savegame preview & metadata, based on #109
- [x] Auto mod installation (ModDataChecker): see table below
  - [x] RedMod: auto deployment before game launch, with load order from MO
- [x] Auto framework installation
  - [x] redscript
  - [x] RED4ext & CET: get moved into `root` to be either copied manually into game install dir or automatic via [RootBuilder](https://kezyma.github.io/?p=rootbuilder)
- ~Sync mod settings back to mods (some are currently saved to overwrite, since config files get created after game launch)~
- [x] Enforce MOs load for `.archive` (`archive/pc/mod/modlist.txt`) and REDmod (`-modlist`)
- [x] RootBuilder config: working default config set automatically (once)

## Mod support
Here is an overview of the mod / framework support as of MO 2.5 beta 14 (Cyberpunk game plugin v2.1) and the compatibility with MOs virtual file system USVFS:
<table>
    <thead>
        <tr>
            <th colspan="2"></th>
            <th colspan="2"> Support: mods&nbsp;/&nbsp;framework </th>
        </tr>
        <tr>
            <th>Mod type / framework</th>
            <th>Mod folder (files)</th>
            <th>Auto install*</th>
            <th>USVFS</th>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>archive</td>
            <td><code>archvie/...</code> <code>(.archive)</code></td>
            <td>✔️/ &ndash;</td>
            <td>✔️/ &ndash;</td>
        </tr>
        <tr>
            <td><a href="https://www.nexusmods.com/cyberpunk2077/mods/1511">redscript</a></td>
            <td><code>r6/...</code> <code>(.reds)</code></td>
            <td>✔️/✔️</td>
            <td>✔️/✔️</td>
        </tr>
        <tr>
            <td><a href="https://www.nexusmods.com/cyberpunk2077/mods/2380">RED4ext</a></td>
            <td><code>red4ext/...</code> <code>(.dll)</code></td>
            <td>✔️/✔️<sup><a href="#f-root">root</a></sup></td>
            <td>✔️/❌*</td>
        </tr>
        <tr>
            <td><a href="https://www.nexusmods.com/cyberpunk2077/mods/107">Cyber Engine Tweaks (CET)</a></td>
            <td><code>bin/x64/plugins/...</code> <code>(.lua)</code></td>
            <td>✔️/✔️<sup><a href="#f-root">root</a></sup></td>
            <td>✔️&nbsp;1.27 / ❌*</td>
        </tr>
        <tr>
            <td><a href="https://www.cyberpunk.net/en/modding-support">REDMod</a></td>
            <td><code>mods/*</code> <code>(info.json, ...)</code></td>
            <td>✔️/❌(DLC)</td>
            <td>✔️/❌(DLC)</td>
        </tr>
    </tbody>
</table>

<b id="f-root">root:</b> Auto install only into (virtual) `root` folder, compatible with  [RootBuilder](https://kezyma.github.io/?p=rootbuilder) (copy/hardlink). Alternative: copy manually into game dir.

\* Remarks
- [RED4ext](https://www.nexusmods.com/cyberpunk2077/mods/2380): Only the framework (2 `.dll` files) need to be copied / hard linked to `root`, dependent mods work with USVFS then.
- [Cyber Engine Tweaks (CET)](https://www.nexusmods.com/cyberpunk2077/mods/107):
  - Cyberpunk v2.01, CET &ge;1.27: only CET framework needs to be copies / hard linked into `root` (all files), mods work with USVFS.
  - Cyberpunk v1.x, CET &le;1.26: is not compatible with USVFS, see [CET issue / PR](/maximegmd/CyberEngineTweaks/pull/877) for details.
- [RedMod](https://www.cyberpunk.net/en/modding-support): precompilation is now supported
- [RootBuilder](https://kezyma.github.io/?p=rootbuilder) can be used to automate hard linking / coping `root` files into game dir (only frameworks RED4ext and CET, no mods)


Tested with:
- Cyberpunk 2077 v2.01
- MO v2.5.0 beta 12+
- RootBuilder 4.4 (copy mode) and 4.5 (hard link mode)

Related issues:
- Fixes ModOrganizer2/modorganizer#1742
- Fixes ModOrganizer2/modorganizer#1719
- Fixes ModOrganizer2/modorganizer#1487