### PR TITLE
Add Fallout 76 support (basic)

### DIFF
--- a/games/game_fallout76.py
+++ b/games/game_fallout76.py
@@ -5,13 +5,16 @@ class Fallout76Game(BasicGame):
 
     Name = "Fallout 76 Support Plugin"
     Author = "TDarkShadow"
-    Version = "1.0.0"
+    Version = "1.0.1"
 
     GameName = "Fallout 76"
     GameShortName = "f76"
     GameBinary = "Fallout76.exe"
-    GameDataPath = "%GAME_PATH%"
+    GameDataPath = "%GAME_PATH%/Data"
     GameDocumentsDirectory = "%DOCUMENTS%/My Games/Fallout 76"
     GameSteamId = 1151340
     GameNexusId = 2590
     GameNexusName = "fallout76"
+
+    def iniFiles(self):
+        return ["Fallout76.ini, Fallout76Prefs.ini, Fallout76Custom.ini"]

--- a/games/game_fallout76.py
+++ b/games/game_fallout76.py
@@ -1,0 +1,17 @@
+from ..basic_game import BasicGame
+
+
+class Fallout76Game(BasicGame):
+
+    Name = "Fallout 76 Support Plugin"
+    Author = "TDarkShadow"
+    Version = "1.0.0"
+
+    GameName = "Fallout 76"
+    GameShortName = "f76"
+    GameBinary = "Fallout76.exe"
+    GameDataPath = "%GAME_PATH%"
+    GameDocumentsDirectory = "%DOCUMENTS%/My Games/Fallout 76"
+    GameSteamId = 1151340
+    GameNexusId = 2590
+    GameNexusName = "fallout76"

--- a/games/game_fallout76.py
+++ b/games/game_fallout76.py
@@ -2,7 +2,6 @@ from ..basic_game import BasicGame
 
 
 class Fallout76Game(BasicGame):
-
     Name = "Fallout 76 Support Plugin"
     Author = "TDarkShadow"
     Version = "1.0.1"


### PR DESCRIPTION
Adding basic game support for Fallout 76.
Some of the basic functionalities are still missing like a mod data checker and an archive loader but require a bit more Python experience / knowledge than what I currently have.
Fix ModOrganizer2/modorganizer#1620

This is a basic game support replacement until a decent plugin can be developed (ModOrganizer2/modorganizer#1187).