### PR TITLE
Fix valid match in `BasicModDataChecker.dataLooksValid()`

### DIFF
--- a/basic_features/basic_mod_data_checker.py
+++ b/basic_features/basic_mod_data_checker.py
@@ -179,8 +179,9 @@ class BasicModDataChecker(mobase.ModDataChecker):
                 else:
                     status = mobase.ModDataChecker.INVALID
                     break
-            elif rp.valid.match(name) and status == mobase.ModDataChecker.INVALID:
-                status = mobase.ModDataChecker.VALID
+            elif rp.valid.match(name):
+                if status is mobase.ModDataChecker.INVALID:
+                    status = mobase.ModDataChecker.VALID
             elif rp.delete.match(name) or rp.move_match(name) is not None:
                 status = mobase.ModDataChecker.FIXABLE
             else:


### PR DESCRIPTION
Fix for `valid` patterns not being accepted by `BasicModDataChecker.dataLooksValid()`, for more than one folder / file.

Affected games: Valheim, Subnautica (, Cyberpunk)