### PR TITLE
Add BasicLocalSavegames (basic_feature)

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,7 +179,8 @@ The meta-plugin provides some useful extra feature:
 2. **Basic save game preview:** If you use the Python version, and if you can easily obtain a picture (file)
   for any saves, you can provide basic save-game preview by using the `BasicGameSaveGameInfo`.
   See [games/game_witcher3.py](games/game_witcher3.py) for  more details.
-3. **Basic mod data checker** (Python):
+3. **Basic local save games** (Python): profile specific save games, as in [games/game_valheim.py](games/game_valheim.py).
+4. **Basic mod data checker** (Python):
   Check and fix different mod archive layouts for an automatic installation with the proper
   file structure, using simple (glob) patterns via `BasicModDataChecker`.
   See [games/game_valheim.py](games/game_valheim.py) and [game_subnautica.py](games/game_subnautica.py) for an example.

--- a/basic_features/__init__.py
+++ b/basic_features/__init__.py
@@ -1,4 +1,10 @@
+from .basic_local_savegames import BasicLocalSavegames
 from .basic_mod_data_checker import BasicModDataChecker, GlobPatterns
 from .basic_save_game_info import BasicGameSaveGameInfo
 
-__all__ = ["BasicModDataChecker", "BasicGameSaveGameInfo", "GlobPatterns"]
+__all__ = [
+    "BasicModDataChecker",
+    "BasicGameSaveGameInfo",
+    "GlobPatterns",
+    "BasicLocalSavegames",
+]

--- a/basic_features/basic_local_savegames.py
+++ b/basic_features/basic_local_savegames.py
@@ -1,0 +1,21 @@
+import mobase
+from PyQt6.QtCore import QDir
+
+
+class BasicLocalSavegames(mobase.LocalSavegames):
+    def __init__(self, game_save_dir: QDir):
+        super().__init__()
+        self._game_saves_dir = game_save_dir.absolutePath()
+
+    def mappings(self, profile_save_dir: QDir):
+        return [
+            mobase.Mapping(
+                source=profile_save_dir.absolutePath(),
+                destination=self._game_saves_dir,
+                is_directory=True,
+                create_target=True,
+            )
+        ]
+
+    def prepareProfile(self, profile: mobase.IProfile) -> bool:
+        return profile.localSavesEnabled()

--- a/games/game_blackandwhite2.py
+++ b/games/game_blackandwhite2.py
@@ -11,6 +11,7 @@ from PyQt6.QtCore import QDateTime, QDir, QFile, QFileInfo, Qt
 from PyQt6.QtGui import QPainter, QPixmap
 from PyQt6.QtWidgets import QWidget
 
+from ..basic_features import BasicLocalSavegames
 from ..basic_features.basic_save_game_info import (
     BasicGameSaveGame,
     BasicGameSaveGameInfo,
@@ -224,25 +225,6 @@ class BlackAndWhite2SaveGame(BasicGameSaveGame):
         return self._filepath.parent.parent.name
 
 
-class BlackAndWhite2LocalSavegames(mobase.LocalSavegames):
-    def __init__(self, my_game_save_dir: QDir):
-        super().__init__()
-        self._savesDir = my_game_save_dir.absolutePath()
-
-    def mappings(self, profile_save_dir: QDir) -> list[mobase.Mapping]:
-        m = mobase.Mapping()
-
-        m.createTarget = True
-        m.isDirectory = True
-        m.source = profile_save_dir.absolutePath()
-        m.destination = self._savesDir
-
-        return [m]
-
-    def prepareProfile(self, profile: mobase.IProfile):
-        return profile.localSavesEnabled()
-
-
 def _getPreview(savepath: Path):
     save = BlackAndWhite2SaveGame(savepath)
     lines = [
@@ -365,7 +347,7 @@ class BlackAndWhite2Game(BasicGame, mobase.IPluginFileMapper):
     def init(self, organizer: mobase.IOrganizer) -> bool:
         BasicGame.init(self, organizer)
         self._featureMap[mobase.ModDataChecker] = BlackAndWhite2ModDataChecker()
-        self._featureMap[mobase.LocalSavegames] = BlackAndWhite2LocalSavegames(
+        self._featureMap[mobase.LocalSavegames] = BasicLocalSavegames(
             self.savesDirectory()
         )
         self._featureMap[mobase.SaveGameInfo] = BlackAndWhite2SaveGameInfo(_getPreview)

--- a/games/game_valheim.py
+++ b/games/game_valheim.py
@@ -11,7 +11,7 @@ from typing import Any, Optional, TextIO
 import mobase
 from PyQt6.QtCore import QDir
 
-from ..basic_features.basic_mod_data_checker import BasicModDataChecker, GlobPatterns
+from ..basic_features import BasicLocalSavegames, BasicModDataChecker, GlobPatterns
 from ..basic_features.basic_save_game_info import BasicGameSaveGame
 from ..basic_game import BasicGame
 
@@ -286,25 +286,6 @@ class ValheimWorldSaveGame(ValheimSaveGame):
         return files
 
 
-class ValheimLocalSavegames(mobase.LocalSavegames):
-    def __init__(self, my_game_save_dir: QDir):
-        super().__init__()
-        self._saves_dir = my_game_save_dir.absolutePath()
-
-    def mappings(self, profile_save_dir: QDir):
-        return [
-            mobase.Mapping(
-                source=profile_save_dir.absolutePath(),
-                destination=self._saves_dir,
-                is_directory=True,
-                create_target=True,
-            )
-        ]
-
-    def prepareProfile(self, profile: mobase.IProfile):
-        return profile.localSavesEnabled()
-
-
 class ValheimGame(BasicGame):
     Name = "Valheim Support Plugin"
     Author = "Zash"
@@ -377,7 +358,7 @@ class ValheimGame(BasicGame):
                 },
             )
         )
-        self._featureMap[mobase.LocalSavegames] = ValheimLocalSavegames(
+        self._featureMap[mobase.LocalSavegames] = BasicLocalSavegames(
             self.savesDirectory()
         )
         self._overwrite_sync = OverwriteSync(organizer=self._organizer, game=self)

--- a/games/game_vampirebloodlines.py
+++ b/games/game_vampirebloodlines.py
@@ -4,6 +4,7 @@ from typing import List
 import mobase
 from PyQt6.QtCore import QDir
 
+from ..basic_features import BasicLocalSavegames
 from ..basic_game import BasicGame, BasicGameSaveGame
 
 
@@ -48,24 +49,6 @@ class VampireSaveGame(BasicGameSaveGame):
         self.elapsedTime = None
 
 
-class VampireLocalSavegames(mobase.LocalSavegames):
-    def __init__(self, my_game_save_dir: QDir):
-        super().__init__()
-        self._saves_dir = my_game_save_dir.absolutePath()
-
-    def mappings(self, profile_save_dir: QDir):
-        m = mobase.Mapping()
-        m.createTarget = True
-        m.isDirectory = True
-        m.source = profile_save_dir.absolutePath()
-        m.destination = self._saves_dir
-
-        return [m]
-
-    def prepareProfile(self, profile: mobase.IProfile):
-        return profile.localSavesEnabled()
-
-
 class VampireTheMasqueradeBloodlinesGame(BasicGame):
     Name = "Vampire - The Masquerade: Bloodlines Support Plugin"
     Author = "John"
@@ -91,7 +74,7 @@ class VampireTheMasqueradeBloodlinesGame(BasicGame):
     def init(self, organizer: mobase.IOrganizer) -> bool:
         super().init(organizer)
         self._featureMap[mobase.ModDataChecker] = VampireModDataChecker()
-        self._featureMap[mobase.LocalSavegames] = VampireLocalSavegames(
+        self._featureMap[mobase.LocalSavegames] = BasicLocalSavegames(
             self.savesDirectory()
         )
         return True


### PR DESCRIPTION
Simplifies adding profile specific save games, by adding a default implementation of  `LocalSavegames`,
`BasicLocalSavegames`, to `basic_features`.

Refactors games using `LocalSavegames`, since they all use the same implementation anyways.

Added the class in a separate `basic_local_savegames`, would alternatively also fit into `basic_save_game_info`
