### PR TITLE
Add mapping `GameIniFiles`: `iniFiles()` to BasicGame

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,7 @@ class Witcher3Game(BasicGame):
 | GameLauncher | Name of the game launcher, relative to the game path  (Optional) | `getLauncherName` | `str` |
 | GameDataPath | Name of the folder containing mods, relative to game folder| `dataDirectory` | |
 | GameDocumentsDirectory | Documents directory (Optional) | `documentsDirectory` | `str` or `QDir` |
+| GameIniFiles | Config files in documents, for profile specific config (Optional) | `iniFiles` | `str` or `List[str]` |
 | GameSavesDirectory | Directory containing saves (Optional, default to `GameDocumentsDirectory`) | `savesDirectory` | `str` or `QDir` |
 | GameSaveExtension | Save file extension (Optional) `savegameExtension` | `str` |
 | GameSteamId | Steam ID of the game (Optional) | `steamAPPId` | `List[str]` or `str` or `int` |

--- a/basic_game.py
+++ b/basic_game.py
@@ -204,6 +204,7 @@ class BasicGameMappings:
     launcherName: BasicGameMapping[str]
     dataDirectory: BasicGameMapping[str]
     documentsDirectory: BasicGameMapping[QDir]
+    iniFiles: BasicGameMapping[list[str]]
     savesDirectory: BasicGameMapping[QDir]
     savegameExtension: BasicGameMapping[str]
     steamAPPId: BasicGameOptionsMapping[str]
@@ -289,6 +290,15 @@ class BasicGameMappings:
             "documentsDirectory",
             apply_fn=lambda s: QDir(s) if isinstance(s, str) else s,
             default=BasicGameMappings._default_documents_directory,
+        )
+        self.iniFiles = BasicGameMapping(
+            game,
+            "GameIniFiles",
+            "iniFiles",
+            lambda g: [],
+            apply_fn=lambda value: [c.strip() for c in value.split(",")]
+            if isinstance(value, str)
+            else value,
         )
         self.savesDirectory = BasicGameMapping(
             game,
@@ -542,6 +552,9 @@ class BasicGame(mobase.IPluginGame):
 
     def getSupportURL(self) -> str:
         return self._mappings.supportURL.get()
+
+    def iniFiles(self) -> list[str]:
+        return self._mappings.iniFiles.get()
 
     def executables(self) -> list[mobase.ExecutableInfo]:
         execs: list[mobase.ExecutableInfo] = []


### PR DESCRIPTION
Just noticed that this is missing.
Makes it also possible to enable profile specific ini files from a `game_xy.ini` basic game config.
Same parsing as `GameValidShortNames`.

Could also replace all existing `iniFiles()` definitions with the property, to make it clear for others?