### PR TITLE
Fix mods expecting alphabetical load order

### DIFF
--- a/games/game_cyberpunk2077.py
+++ b/games/game_cyberpunk2077.py
@@ -377,7 +377,7 @@ class Cyberpunk2077Game(BasicGame):
                     "Enforce the current load order via"
                     " <code>archive/pc/mod/modlist.txt</code>"
                 ),
-                True,
+                False,
             ),
             mobase.PluginSetting(
                 "enforce_redmod_load_order",


### PR DESCRIPTION
Disable `enforce_archive_load_order` by default.
With the setting enabled, Mod Organizers load order is enforced for mods with `.archive` files. But most mod (authors) are expecting all `.archive` files to load in alphabetic order, with files in depended mods named accordingly.

Setting can be enabled for a manual archive conflict resolution via MOs load order.