### PR TITLE
Fix ElementTree future warning

### DIFF
--- a/eadesktop_utils.py
+++ b/eadesktop_utils.py
@@ -59,7 +59,7 @@ def find_games() -> Dict[str, Path]:
             # consider these.
             content_id = root.find(".//contentIDs/contentID[1]")
 
-            if content_id and content_id.text:
+            if content_id is not None and content_id.text:
                 game_id = content_id.text
                 games[game_id] = game_dir
         except FileNotFoundError:


### PR DESCRIPTION
ElementTree has a FutureWarning about not using the implicit truthiness test for an Element. So instead use the advertised test against `None` to silence the warning.