### PR TITLE
Fix for Subnautica 2.0

### DIFF
--- a/games/game_subnautica-below-zero.py
+++ b/games/game_subnautica-below-zero.py
@@ -1,8 +1,6 @@
 from __future__ import annotations
 
-import mobase
-
-from ..basic_features.basic_mod_data_checker import GlobPatterns
+from ..basic_features import GlobPatterns
 from . import game_subnautica  # namespace to not load SubnauticaGame here, too!
 
 
@@ -29,11 +27,9 @@ class SubnauticaBelowZeroGame(game_subnautica.SubnauticaGame):
         r"\Subnautica Below Zero\SubnauticaZero\SavedGames"
     ]
 
-    def init(self, organizer: mobase.IOrganizer) -> bool:
-        super().init(organizer)
-        self._featureMap[mobase.ModDataChecker] = (
-            game_subnautica.SubnauticaModDataChecker(
-                GlobPatterns(unfold=["BepInExPack_BelowZero"])
-            )
+    def _set_mod_data_checker(
+        self, extra_patterns: GlobPatterns | None = None, use_qmod: bool | None = None
+    ):
+        super()._set_mod_data_checker(
+            GlobPatterns(unfold=["BepInExPack_BelowZero"]), use_qmod
         )
-        return True

--- a/games/game_subnautica-below-zero.py
+++ b/games/game_subnautica-below-zero.py
@@ -7,7 +7,7 @@ from . import game_subnautica  # namespace to not load SubnauticaGame here, too!
 class SubnauticaBelowZeroGame(game_subnautica.SubnauticaGame):
     Name = "Subnautica Below Zero Support Plugin"
     Author = "dekart811, Zash"
-    Version = "2.1"
+    Version = "2.2"
 
     GameName = "Subnautica: Below Zero"
     GameShortName = "subnauticabelowzero"

--- a/games/game_subnautica.py
+++ b/games/game_subnautica.py
@@ -81,7 +81,7 @@ class SubnauticaModDataChecker(BasicModDataChecker):
 class SubnauticaGame(BasicGame, mobase.IPluginFileMapper):
     Name = "Subnautica Support Plugin"
     Author = "dekart811, Zash"
-    Version = "2.1.1"
+    Version = "2.2"
 
     GameName = "Subnautica"
     GameShortName = "subnautica"

--- a/games/game_subnautica.py
+++ b/games/game_subnautica.py
@@ -97,6 +97,19 @@ class SubnauticaGame(BasicGame, mobase.IPluginFileMapper):
             for folder in Path(save_path).glob("slot*")
         ]
 
+    def executables(self) -> list[mobase.ExecutableInfo]:
+        binary = self.gameDirectory().absoluteFilePath(self.binaryName())
+        return [
+            mobase.ExecutableInfo(
+                self.gameName(),
+                binary,
+            ).withArgument("-vrmode none"),
+            mobase.ExecutableInfo(
+                f"{self.gameName()} VR",
+                self.gameDirectory().absoluteFilePath(self.binaryName()),
+            ),
+        ]
+
     def executableForcedLoads(self) -> list[mobase.ExecutableForcedLoadSetting]:
         return [
             mobase.ExecutableForcedLoadSetting(self.binaryName(), lib).withEnabled(True)


### PR DESCRIPTION
- Launch non VR version by default by adding `-vrmode none` to default exe
- Adds new exe: Subnautica VR (without the vrmode arg)
- Fixes Subnautica 2.0 (and BZ) mod installations (install `*/.dll` mods in `BepInEx/plugins` instead of `QMods`)
- Adds setting `use_qmods` to still use the legacy QMods folder (default=`False`)

TODO after merge:
- update wiki with the changed install method because of deprecated QMods, including the `use_qmods` setting

Edit: merged the fix for VR with the Subnautica 2.0 changes