### PR TITLE
Cyberpunk fixes for 2.5

### DIFF
--- a/games/game_cyberpunk2077.py
+++ b/games/game_cyberpunk2077.py
@@ -487,7 +487,6 @@ class Cyberpunk2077Game(BasicGame):
             qWarning("Aborting game launch.")
             return False  # Auto deploy failed
         self._map_cache_files()
-        return False
         if self._get_setting("enforce_archive_load_order"):
             self._modlist_files.update_modlist("archive")
         return True

--- a/games/game_cyberpunk2077.py
+++ b/games/game_cyberpunk2077.py
@@ -328,12 +328,12 @@ class Cyberpunk2077Game(BasicGame):
             archive=ModListFile(
                 Path("archive/pc/mod/modlist.txt"),
                 "archive/pc/mod/*",
-                reversed_priority=True,
+                reversed_priority=bool(self._get_setting("reverse_archive_load_order")),
             ),
             redmod=ModListFile(
                 Path(self._redmod_deploy_path, "MO_REDmod_load_order.txt"),
                 "mods/*/",
-                reversed_priority=True,
+                reversed_priority=bool(self._get_setting("reverse_redmod_load_order")),
             ),
         )
         self._rootbuilder_settings = PluginDefaultSettings(
@@ -363,7 +363,22 @@ class Cyberpunk2077Game(BasicGame):
         organizer.onUserInterfaceInitialized(apply_rootbuilder_settings_once)
         organizer.onPluginEnabled("RootBuilder", apply_rootbuilder_settings_once)
         organizer.onAboutToRun(self._onAboutToRun)
+
+        organizer.onPluginSettingChanged(self._on_settings_changed)
         return True
+
+    def _on_settings_changed(
+        self,
+        plugin_name: str,
+        setting: str,
+        old: mobase.MoVariant,
+        new: mobase.MoVariant,
+    ):
+        if self.name() == plugin_name:
+            if setting == "reverse_archive_load_order":
+                self._modlist_files["archive"].reversed_priority = bool(new)
+            elif setting == "reverse_remod_load_order":
+                self._modlist_files["redmod"].reversed_priority = bool(new)
 
     def iniFiles(self):
         return ["UserSettings.json"]
@@ -394,9 +409,26 @@ class Cyberpunk2077Game(BasicGame):
                 False,
             ),
             mobase.PluginSetting(
+                "reverse_archive_load_order",
+                (
+                    "Reverse MOs load order in"
+                    " <code>archive/pc/mod/modlist.txt</code>"
+                    " (first loaded mod wins = last one / highest prio in MO)"
+                ),
+                False,
+            ),
+            mobase.PluginSetting(
                 "enforce_redmod_load_order",
                 "Enforce the current load order on redmod deployment",
                 True,
+            ),
+            mobase.PluginSetting(
+                "reverse_redmod_load_order",
+                (
+                    "Reverse MOs load order on redmod deployment"
+                    " (first loaded mod wins = last one / highest prio in MO)"
+                ),
+                False,
             ),
             mobase.PluginSetting(
                 "auto_deploy_redmod",

--- a/games/game_cyberpunk2077.py
+++ b/games/game_cyberpunk2077.py
@@ -379,8 +379,11 @@ class Cyberpunk2077Game(BasicGame):
         return [
             mobase.PluginSetting(
                 "skipStartScreen",
-                'Skips the "Breaching..." start screen on game launch',
-                True,
+                (
+                    'Skips the "Breaching..." start screen on game launch'
+                    " (can also skip loading of GOG rewards)"
+                ),
+                False,
             ),
             mobase.PluginSetting(
                 "enforce_archive_load_order",


### PR DESCRIPTION
Fixes the following in MO 2.5+:
- remove debug return from #137. Sorry, slipped through testing. 
- set default for `skipStartScreen=False`, since it can also skip loading rewards, same as here e.g.: maximegmd/CyberEngineTweaks#663
- reverse the load order only optionally for better backwards compatibility (#132), add settings  `reverse_archive_load_order=False` and  `reverse_redmod_load_order=False` (see below)

Thx @ junki for the issue reports

The default load order settings are a compromise between default Cyberpunk / mod behavior (load mods alphabetically), backwards compatibility (load mods top to bottom = lower prio wins) and MOs known behavior from Skyrim etc. (highest prio mod wins).

Details about the load order as draft for the wiki:
 
## Load order
With an example mod list
```
modB (priority 1)  with archive/pc/mod/B.archive
modA (priority 2)  with archive/pc/mod/A.archive
modC (priority 3)  with archive/pc/mod/C.archive
```

In Cyberpunk the load order of all `.archive` files and REDmod folders is [alphabetically](https://wiki.redmodding.org/cyberpunk-2077-modding/for-mod-users/users-modding-cyberpunk-2077/load-order), as named by mod authors.
The first loaded `.archive` file / mod modifying a game file wins a conflict in CP (in contrast to Skyrim, where esps can overwrite each other), i.e. `A.archive` wins over `B.archive` and `C.archive` (`A > B > C`).

A custom `.archive` load order can be specified with a file `archive/pc/mod/modlist.txt`, which can be generated optionally (setting `enforce_archive_load_order = true`) by MO in `overwrite` before game launch (changing load order to `B > A > C`).
For REDmod, MO passes the load order by default to the precompiler `redmod.exe`. See Settings below.

Note that the load order of multiple `.archive` files within a single mod is still always alphabetically, independent of the settings.

In contrast to that, **direct file conflicts** (same file name) are displayed directly in MOs mod list and here the highest priority always wins.

## Settings:
Under `Tools/Settings/Plugins/Cyberpunk 2077 Support Plugin`:
- `skipStartScreen` (default: `false`): Skips the "Breaching..." start screen on game launch (can also skip loading of GOG rewards) 
- `enforce_archive_load_order` (default: `false`): enforce MOs mod load order via generated `overwrite/archive/pc/mod/modlist.txt`
- `reverse_archive_load_order` (default: `false`): reverse MOs load order in generated `modlist.txt`
  - `false`(default): first / lowest priority mod in MO wins a conflict (`B > A > C`)
  - `true`: last / highest priority mod in MO wins a conflict (`C > A > B`)
- `enforce_redmod_load_order` (default: `true`): enforce MOs mod load order by generating `overwrite/r6/cache/modded/MO_REDmod_load_order.txt`, which is passed to `redmod.exe` before game launch.
- `reverse_redmod_load_order` (default: `false`): reverse the generated redmod list.
- ...
