### PR TITLE
Add Tony Hawk's Pro Skater 3, 4, Underground & Underground 2 Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,10 @@ You can rename `modorganizer-basic_games-xxx` to whatever you want (e.g., `basic
 | Valheim — [STEAM](https://store.steampowered.com/app/892970/Valheim/) | [Zash](https://github.com/ZashIn) | [game_valheim.py](games/game_valheim.py) | <ul><li>mod data checker</li><li>overwrite config sync</li><li>save game support (no preview)</li></ul> |
 | The Witcher: Enhanced Edition - [GOG](https://www.gog.com/game/the_witcher) / [STEAM](https://store.steampowered.com/app/20900/The_Witcher_Enhanced_Edition_Directors_Cut/) | [erri120](https://github.com/erri120) | [game_witcher1.py](games/game_witcher1.py) | <ul><li>save game parsing (no preview)</li></ul> |
 | The Witcher 3: Wild Hunt — [GOG](https://www.gog.com/game/the_witcher_3_wild_hunt) / [STEAM](https://store.steampowered.com/app/292030/The_Witcher_3_Wild_Hunt/) | [Holt59](https://github.com/holt59/) | [game_witcher3.py](games/game_witcher3.py) | <ul><li>save game preview</li></ul> |
+| Tony Hawk's Pro Skater 3 | [uwx](https://github.com/uwx) | [game_thps3.py](games/game_thps3.py) | |
+| Tony Hawk's Pro Skater 4 | [uwx](https://github.com/uwx) | [game_thps4.py](games/game_thps4.py) | |
+| Tony Hawk's Underground | [uwx](https://github.com/uwx) | [game_thug.py](games/game_thug.py) | |
+| Tony Hawk's Underground 2 | [uwx](https://github.com/uwx) | [game_thug2.py](games/game_thug2.py) | |
 | Yu-Gi-Oh! Master Duel — [STEAM](https://store.steampowered.com/app/1449850/) | [The Conceptionist](https://github.com/the-conceptionist) & [uwx](https://github.com/uwx) | [game_masterduel.py](games/game_masterduel.py) | |
 | Zeus and Poseidon — [GOG](https://www.gog.com/game/zeus_poseidon) / [STEAM](https://store.steampowered.com/app/566050/Zeus__Poseidon/) | [Holt59](https://github.com/holt59/) | [game_zeusandpoiseidon.py](games/game_zeusandpoiseidon.py) | <ul><li>mod data checker</li></ul> |
 

--- a/games/game_thps3.py
+++ b/games/game_thps3.py
@@ -1,0 +1,39 @@
+# -*- encoding: utf-8 -*-
+
+from PyQt6.QtCore import QFileInfo
+
+import mobase
+
+from ..basic_game import BasicGame
+
+
+class THPS3Game(BasicGame):
+
+    Name = "Tony Hawk's Pro Skater 3 Support Plugin"
+    Author = "Maxine"
+    Version = "1.0.0"
+
+    GameName = "Tony Hawk's Pro Skater 3"
+    GameShortName = "thps3"
+    GameBinary = "Skate3.exe"
+    GameDataPath = "Data"
+
+    def executables(self):
+        return [
+            mobase.ExecutableInfo(
+                "Tony Hawk's Pro Skater 3",
+                QFileInfo(self.gameDirectory().absoluteFilePath(self.binaryName())),
+            ),
+            mobase.ExecutableInfo(
+                "Tony Hawk's Pro Skater 3 Setup",
+                QFileInfo(self.gameDirectory().absoluteFilePath("THPS3Setup.exe")),
+            ),
+            mobase.ExecutableInfo(
+                "Tony Hawk's Pro Skater 3 (PARTYMOD)",
+                QFileInfo(self.gameDirectory().absoluteFilePath("THPS3.exe")),
+            ),
+            mobase.ExecutableInfo(
+                "PARTYMOD Configurator",
+                QFileInfo(self.gameDirectory().absoluteFilePath("partyconfig.exe")),
+            )
+        ]

--- a/games/game_thps3.py
+++ b/games/game_thps3.py
@@ -1,8 +1,7 @@
 # -*- encoding: utf-8 -*-
 
-from PyQt6.QtCore import QFileInfo
-
 import mobase
+from PyQt6.QtCore import QFileInfo
 
 from ..basic_game import BasicGame
 
@@ -35,5 +34,5 @@ class THPS3Game(BasicGame):
             mobase.ExecutableInfo(
                 "PARTYMOD Configurator",
                 QFileInfo(self.gameDirectory().absoluteFilePath("partyconfig.exe")),
-            )
+            ),
         ]

--- a/games/game_thps3.py
+++ b/games/game_thps3.py
@@ -10,7 +10,7 @@ from ..basic_game import BasicGame
 class THPS3Game(BasicGame):
 
     Name = "Tony Hawk's Pro Skater 3 Support Plugin"
-    Author = "Maxine"
+    Author = "uwx"
     Version = "1.0.0"
 
     GameName = "Tony Hawk's Pro Skater 3"

--- a/games/game_thps4.py
+++ b/games/game_thps4.py
@@ -1,0 +1,39 @@
+# -*- encoding: utf-8 -*-
+
+from PyQt6.QtCore import QFileInfo, QDir
+
+import mobase
+
+from ..basic_game import BasicGame
+
+
+class THPS4Game(BasicGame):
+
+    Name = "Tony Hawk's Pro Skater 4 Support Plugin"
+    Author = "Maxine"
+    Version = "1.0.0"
+
+    GameName = "Tony Hawk's Pro Skater 4"
+    GameShortName = "thps4"
+    GameBinary = "Skate4.exe"
+    GameDataPath = "Data"
+
+    def executables(self):
+        return [
+            mobase.ExecutableInfo(
+                "Tony Hawk's Pro Skater 4",
+                QFileInfo(self.gameDirectory().absoluteFilePath(self.binaryName())),
+            ),
+            mobase.ExecutableInfo(
+                "Tony Hawk's Pro Skater 4 Setup",
+                QFileInfo(self.gameDirectory().absoluteFilePath("../Start.exe"))
+            ).withWorkingDirectory(QDir(QDir.cleanPath(self.gameDirectory().absoluteFilePath("..")))),
+            mobase.ExecutableInfo(
+                "Tony Hawk's Pro Skater 4 (PARTYMOD)",
+                QFileInfo(self.gameDirectory().absoluteFilePath("THPS4.exe")),
+            ),
+            mobase.ExecutableInfo(
+                "PARTYMOD Configurator",
+                QFileInfo(self.gameDirectory().absoluteFilePath("partyconfig.exe")),
+            )
+        ]

--- a/games/game_thps4.py
+++ b/games/game_thps4.py
@@ -10,7 +10,7 @@ from ..basic_game import BasicGame
 class THPS4Game(BasicGame):
 
     Name = "Tony Hawk's Pro Skater 4 Support Plugin"
-    Author = "Maxine"
+    Author = "uwx"
     Version = "1.0.0"
 
     GameName = "Tony Hawk's Pro Skater 4"

--- a/games/game_thps4.py
+++ b/games/game_thps4.py
@@ -1,8 +1,7 @@
 # -*- encoding: utf-8 -*-
 
-from PyQt6.QtCore import QFileInfo, QDir
-
 import mobase
+from PyQt6.QtCore import QDir, QFileInfo
 
 from ..basic_game import BasicGame
 
@@ -26,8 +25,10 @@ class THPS4Game(BasicGame):
             ),
             mobase.ExecutableInfo(
                 "Tony Hawk's Pro Skater 4 Setup",
-                QFileInfo(self.gameDirectory().absoluteFilePath("../Start.exe"))
-            ).withWorkingDirectory(QDir(QDir.cleanPath(self.gameDirectory().absoluteFilePath("..")))),
+                QFileInfo(self.gameDirectory().absoluteFilePath("../Start.exe")),
+            ).withWorkingDirectory(
+                QDir(QDir.cleanPath(self.gameDirectory().absoluteFilePath("..")))
+            ),
             mobase.ExecutableInfo(
                 "Tony Hawk's Pro Skater 4 (PARTYMOD)",
                 QFileInfo(self.gameDirectory().absoluteFilePath("THPS4.exe")),
@@ -35,5 +36,5 @@ class THPS4Game(BasicGame):
             mobase.ExecutableInfo(
                 "PARTYMOD Configurator",
                 QFileInfo(self.gameDirectory().absoluteFilePath("partyconfig.exe")),
-            )
+            ),
         ]

--- a/games/game_thug.py
+++ b/games/game_thug.py
@@ -1,0 +1,35 @@
+# -*- encoding: utf-8 -*-
+
+from PyQt6.QtCore import QFileInfo, QDir
+
+import mobase
+
+from ..basic_game import BasicGame
+
+
+class THPS4Game(BasicGame):
+
+    Name = "Tony Hawk's Underground Support Plugin"
+    Author = "Maxine"
+    Version = "1.0.0"
+
+    GameName = "Tony Hawk's Underground"
+    GameShortName = "thug"
+    GameBinary = "THUG.exe"
+    GameDataPath = "Data"
+
+    def executables(self):
+        return [
+            mobase.ExecutableInfo(
+                "Tony Hawk's Underground",
+                QFileInfo(self.gameDirectory().absoluteFilePath(self.binaryName())),
+            ),
+            mobase.ExecutableInfo(
+                "Tony Hawk's Underground Launcher",
+                QFileInfo(self.gameDirectory().absoluteFilePath("../Launcher.exe"))
+            ).withWorkingDirectory(QDir(QDir.cleanPath(self.gameDirectory().absoluteFilePath("..")))),
+            mobase.ExecutableInfo(
+                "Tony Hawk's Underground (ClownJob'd)",
+                QFileInfo(self.gameDirectory().absoluteFilePath("THUGONE.exe")),
+            )
+        ]

--- a/games/game_thug.py
+++ b/games/game_thug.py
@@ -10,7 +10,7 @@ from ..basic_game import BasicGame
 class THPS4Game(BasicGame):
 
     Name = "Tony Hawk's Underground Support Plugin"
-    Author = "Maxine"
+    Author = "uwx"
     Version = "1.0.0"
 
     GameName = "Tony Hawk's Underground"

--- a/games/game_thug.py
+++ b/games/game_thug.py
@@ -1,8 +1,7 @@
 # -*- encoding: utf-8 -*-
 
-from PyQt6.QtCore import QFileInfo, QDir
-
 import mobase
+from PyQt6.QtCore import QDir, QFileInfo
 
 from ..basic_game import BasicGame
 
@@ -26,10 +25,12 @@ class THPS4Game(BasicGame):
             ),
             mobase.ExecutableInfo(
                 "Tony Hawk's Underground Launcher",
-                QFileInfo(self.gameDirectory().absoluteFilePath("../Launcher.exe"))
-            ).withWorkingDirectory(QDir(QDir.cleanPath(self.gameDirectory().absoluteFilePath("..")))),
+                QFileInfo(self.gameDirectory().absoluteFilePath("../Launcher.exe")),
+            ).withWorkingDirectory(
+                QDir(QDir.cleanPath(self.gameDirectory().absoluteFilePath("..")))
+            ),
             mobase.ExecutableInfo(
                 "Tony Hawk's Underground (ClownJob'd)",
                 QFileInfo(self.gameDirectory().absoluteFilePath("THUGONE.exe")),
-            )
+            ),
         ]

--- a/games/game_thug2.py
+++ b/games/game_thug2.py
@@ -11,7 +11,7 @@ from ..basic_game import BasicGame
 class THPS4Game(BasicGame):
 
     Name = "Tony Hawk's Underground 2 Support Plugin"
-    Author = "Maxine"
+    Author = "uwx"
     Version = "1.0.0"
 
     GameName = "Tony Hawk's Underground 2"

--- a/games/game_thug2.py
+++ b/games/game_thug2.py
@@ -1,9 +1,9 @@
 # -*- encoding: utf-8 -*-
 
-from PyQt6.QtCore import QFileInfo, QDir
+import os
 
 import mobase
-import os
+from PyQt6.QtCore import QDir, QFileInfo
 
 from ..basic_game import BasicGame
 
@@ -27,18 +27,28 @@ class THPS4Game(BasicGame):
             ),
             mobase.ExecutableInfo(
                 "Tony Hawk's Underground 2 Launcher",
-                QFileInfo(self.gameDirectory().absoluteFilePath("../Launcher.exe"))
-            ).withWorkingDirectory(QDir(QDir.cleanPath(self.gameDirectory().absoluteFilePath("..")))),
+                QFileInfo(self.gameDirectory().absoluteFilePath("../Launcher.exe")),
+            ).withWorkingDirectory(
+                QDir(QDir.cleanPath(self.gameDirectory().absoluteFilePath("..")))
+            ),
             mobase.ExecutableInfo(
                 "Tony Hawk's Underground 2 (ClownJob'd)",
                 QFileInfo(self.gameDirectory().absoluteFilePath("THUGTWO.exe")),
             ),
             mobase.ExecutableInfo(
                 "THUG Pro Launcher",
-                QFileInfo(QDir(os.getenv('LOCALAPPDATA')).absoluteFilePath("THUG Pro/THUGProLauncher.exe")),
+                QFileInfo(
+                    QDir(os.getenv("LOCALAPPDATA")).absoluteFilePath(
+                        "THUG Pro/THUGProLauncher.exe"
+                    )
+                ),
             ),
             mobase.ExecutableInfo(
                 "THUG Pro",
-                QFileInfo(QDir(os.getenv('LOCALAPPDATA')).absoluteFilePath("THUG Pro/THUGPro.exe")),
+                QFileInfo(
+                    QDir(os.getenv("LOCALAPPDATA")).absoluteFilePath(
+                        "THUG Pro/THUGPro.exe"
+                    )
+                ),
             ),
         ]

--- a/games/game_thug2.py
+++ b/games/game_thug2.py
@@ -1,0 +1,44 @@
+# -*- encoding: utf-8 -*-
+
+from PyQt6.QtCore import QFileInfo, QDir
+
+import mobase
+import os
+
+from ..basic_game import BasicGame
+
+
+class THPS4Game(BasicGame):
+
+    Name = "Tony Hawk's Underground 2 Support Plugin"
+    Author = "Maxine"
+    Version = "1.0.0"
+
+    GameName = "Tony Hawk's Underground 2"
+    GameShortName = "thug2"
+    GameBinary = "THUG2.exe"
+    GameDataPath = "Data"
+
+    def executables(self):
+        return [
+            mobase.ExecutableInfo(
+                "Tony Hawk's Underground 2",
+                QFileInfo(self.gameDirectory().absoluteFilePath(self.binaryName())),
+            ),
+            mobase.ExecutableInfo(
+                "Tony Hawk's Underground 2 Launcher",
+                QFileInfo(self.gameDirectory().absoluteFilePath("../Launcher.exe"))
+            ).withWorkingDirectory(QDir(QDir.cleanPath(self.gameDirectory().absoluteFilePath("..")))),
+            mobase.ExecutableInfo(
+                "Tony Hawk's Underground 2 (ClownJob'd)",
+                QFileInfo(self.gameDirectory().absoluteFilePath("THUGTWO.exe")),
+            ),
+            mobase.ExecutableInfo(
+                "THUG Pro Launcher",
+                QFileInfo(QDir(os.getenv('LOCALAPPDATA')).absoluteFilePath("THUG Pro/THUGProLauncher.exe")),
+            ),
+            mobase.ExecutableInfo(
+                "THUG Pro",
+                QFileInfo(QDir(os.getenv('LOCALAPPDATA')).absoluteFilePath("THUG Pro/THUGPro.exe")),
+            ),
+        ]


### PR DESCRIPTION
Adds support for:

- Tony Hawk's Pro Skater 3
- Tony Hawk's Pro Skater 4
- Tony Hawk's Underground
- Tony Hawk's Underground 2

These games all run on a very similar engine but the ports are made by different porting studios so they work slightly different. Support is included for PARTYMOD for THPS3 & 4 and ClownJob'd for THUG1 & THUG2 which provide replacement game executables with several fixes for controller input, etc. THUG2 also supports THUGPRO, but THUGPRO modding is very limited.