### PR TITLE
Cyberpunk plugin update for MO 2.5.2

### DIFF
--- a/games/game_cyberpunk2077.py
+++ b/games/game_cyberpunk2077.py
@@ -289,7 +289,7 @@ class PluginDefaultSettings:
 class Cyberpunk2077Game(BasicGame):
     Name = "Cyberpunk 2077 Support Plugin"
     Author = "6788, Zash"
-    Version = "2.2.3"
+    Version = "2.3"
 
     GameName = "Cyberpunk 2077"
     GameShortName = "cyberpunk2077"

--- a/games/game_cyberpunk2077.py
+++ b/games/game_cyberpunk2077.py
@@ -289,7 +289,7 @@ class PluginDefaultSettings:
 class Cyberpunk2077Game(BasicGame):
     Name = "Cyberpunk 2077 Support Plugin"
     Author = "6788, Zash"
-    Version = "2.3"
+    Version = "2.3.1"
 
     GameName = "Cyberpunk 2077"
     GameShortName = "cyberpunk2077"
@@ -342,7 +342,10 @@ class Cyberpunk2077Game(BasicGame):
             {
                 "usvfsmode": False,
                 "linkmode": False,
-                "linkonlymode": True,  # RootBuilder v4.5
+                # Available with RootBuilder v4.5+
+                # Currently bugged / incompatible with MO 2.5.2 (Python 3.12)
+                # https://github.com/Kezyma/ModOrganizer-Plugins/issues/36
+                "linkonlymode": False,
                 "backup": True,
                 "cache": True,
                 "autobuild": True,


### PR DESCRIPTION
- [x] update wiki with info about Cyberpunk and MOs [load order](/ModOrganizer2/modorganizer-basic_games/wiki/Game:-Cyberpunk-2077#load-order)
- [x] plugin version bump (v2.3.1) for wiki reference
- [x] check MO compatibility with `REDprelauncher.exe` => ~remove the executable option if necessary~

Will be addressed later:
- [ ] note and link necessary RootBuilder update: Kezyma/ModOrganizer-Plugins/issues/36
- [ ] possibly fix profile specific save files (existing ones are not moved or similar)