### PR TITLE
Fix Source contains parsing errors: '<string>' with EAUtils

### DIFF
--- a/eadesktop_utils.py
+++ b/eadesktop_utils.py
@@ -20,7 +20,7 @@ def find_games() -> Dict[str, Path]:
 
     local_app_data_path = os.path.expandvars("%LocalAppData%")
     ea_desktop_settings_path = Path(local_app_data_path).joinpath(
-        "Electronic Arts", "EA Desktop"
+        "Electronic Arts", "EA Desktop", "EA"
     )
 
     if not ea_desktop_settings_path.exists():


### PR DESCRIPTION
On my system launching ModOrganizer2 causes this error: 
[mo_interface.log](https://github.com/user-attachments/files/16503325/mo_interface.log)
Which cause this interface to appear everytime you Launch the .exe:
![image](https://github.com/user-attachments/assets/e43d9226-de0c-47f2-8582-f40a62810943)

This Pull Request add "EA" as a string which seems to fix this parsing error and remove that error at launch.