### PR TITLE
Fix parsing error if user file is broken

### DIFF
--- a/eadesktop_utils.py
+++ b/eadesktop_utils.py
@@ -37,7 +37,10 @@ def find_games() -> Dict[str, Path]:
         ini_content = "[mod_organizer]\n" + f.read()
 
     config = configparser.ConfigParser()
-    config.read_string(ini_content)
+    try:
+        config.read_string(ini_content)
+    except ValueError:
+        return
 
     try:
         install_path = Path(config.get("mod_organizer", "user.downloadinplacedir"))


### PR DESCRIPTION
Catch errors if the EA user file is broken to avoid erroring at launch.
Should fix the issue correctly.