### PR TITLE
Fix Subnautica installer error

### DIFF
--- a/games/game_subnautica.py
+++ b/games/game_subnautica.py
@@ -53,6 +53,10 @@ class SubnauticaModDataChecker(BasicModDataChecker):
     def dataLooksValid(
         self, filetree: mobase.IFileTree
     ) -> mobase.ModDataChecker.CheckReturn:
+        # fix: single root folders get traversed by Simple Installer
+        parent = filetree.parent()
+        if parent is not None and self.dataLooksValid(parent) is self.FIXABLE:
+            return self.FIXABLE
         check_return = super().dataLooksValid(filetree)
         # A single unknown folder with a dll file in is to be moved to BepInEx/plugins/
         if (

--- a/games/game_subnautica.py
+++ b/games/game_subnautica.py
@@ -32,6 +32,9 @@ class SubnauticaModDataChecker(BasicModDataChecker):
                     "run_bepinex.sh",
                     "winhttp.dll",
                     "QMods",
+                    ".doorstop_version",  # Added in Tobey's BepInEx Pack for Subnautica v5.4.23
+                    "changelog.txt",
+                    "libdoorstop.dylib",
                 ],
                 delete=[
                     "*.txt",


### PR DESCRIPTION
Fixes error
```
[installerquick.cpp:168] unsupported archive for quick installer
```
Adds (common) workaround for `installerquick` traversing into single folder file tree even when plugin returns `FIXABLE` on root.

Also adds support for new files in [Tobey's BepInEx Pack for Subnautica v5.4.23](https://www.nexusmods.com/subnautica/mods/1108?tab=files)