### PR TITLE
Fix for basic mod data checker

### DIFF
--- a/basic_features/basic_mod_data_checker.py
+++ b/basic_features/basic_mod_data_checker.py
@@ -171,6 +171,11 @@ class BasicModDataChecker(mobase.ModDataChecker):
     ) -> mobase.ModDataChecker.CheckReturn:
         status = mobase.ModDataChecker.INVALID
 
+        # fix: single root folders get traversed by Simple Installer
+        parent = filetree.parent()
+        if parent is not None and self.dataLooksValid(parent) is self.FIXABLE:
+            return self.FIXABLE
+
         rp = self._regex_patterns
         for entry in filetree:
             name = entry.name().casefold()


### PR DESCRIPTION
Fixes "unsupported archive for quick installer" error when trying to quick install an archive that has a single folder that gets moved by the data fixer. This is the same error and fix from [this pull request](https://github.com/ModOrganizer2/modorganizer-basic_games/pull/157), but for the basic mod data checker.