### PR TITLE
Use glob.escape for paths that contain square brackets

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -22,13 +22,14 @@ def createPlugins():
 
     # We are going to list all game plugins:
     curpath = os.path.abspath(os.path.dirname(__file__))
+    escaped_games_path = glob.escape(os.path.join(curpath, "games"))
 
     # List all the .ini files:
-    for file in glob.glob(os.path.join(curpath, "games", "*.ini")):
+    for file in glob.glob(os.path.join(escaped_games_path, "*.ini")):
         game_plugins.append(BasicIniGame(file))
 
     # List all the python plugins:
-    for file in glob.glob(os.path.join(curpath, "games", "*.py")):
+    for file in glob.glob(os.path.join(escaped_games_path, "*.py")):
         module_p = os.path.relpath(file, os.path.join(curpath, "games"))
         if module_p == "__init__.py":
             continue


### PR DESCRIPTION
This should address an issue where basic game plugins are not loaded when the path to basic_games/games contains square brackets. 