### PR TITLE
Cyberpunk: forced load libraries instead of RB

### DIFF
--- a/games/game_cyberpunk2077.py
+++ b/games/game_cyberpunk2077.py
@@ -581,7 +581,10 @@ class Cyberpunk2077Game(BasicGame):
             self._is_cache_file_updated(file, data_path) for file in cache_files
         ):
             qInfo('Updated game files detected, clearing "overwrite/r6/cache/*"')
-            shutil.rmtree(overwrite_path / "r6/cache")
+            try:
+                shutil.rmtree(overwrite_path / "r6/cache")
+            except FileNotFoundError:
+                pass
             new_cache_files = cache_files
         else:
             new_cache_files = list(self._unmapped_cache_files(data_path))


### PR DESCRIPTION
Remove RootBuilder support/requirement (for CET and RED4ext) in favor of forced load libraries:
CET and RED4ext will be installed normally via USVFS instead into `root` folder for RB.

Here is a [test release](https://github.com/ZashIn/modorganizer-basic_games/releases/tag/cyberpunk-v3.0b) for the current MO v2.5.2.

This needs to be tested on larger mod lists for stability!
Additional discussion: https://github.com/CDPR-Modding-Documentation/Cyberpunk-Modding-Docs/pull/37

### TODO:
- [x] Dialog to convert existing mod lists using RB for CET and RED4ext
- [ ] **After release**: update wiki with simpler installation
  - [x]  Add info for CrashReporter with CET and VFS
  - [ ] Remove / move RB requirement and instructions

Extras (in separate PR?):
- [ ] Simplify load order handling, by changing defaults and notifying / converting old mod lists
- [ ] fix profile specific save files (existing ones are not moved or similar)