### PR TITLE
Cyberpunk: Only include .archive files from archive/pc/mod/

### DIFF
--- a/games/game_cyberpunk2077.py
+++ b/games/game_cyberpunk2077.py
@@ -327,7 +327,7 @@ class Cyberpunk2077Game(BasicGame):
             organizer,
             archive=ModListFile(
                 Path("archive/pc/mod/modlist.txt"),
-                "archive/pc/mod/*",
+                "archive/pc/mod/*.archive",
                 reversed_priority=bool(self._get_setting("reverse_archive_load_order")),
             ),
             redmod=ModListFile(


### PR DESCRIPTION
Without this, modlist.txt ends up in the modlist, along with all the .xl files for ArchiveXL. While this doesn't seem to cause issues, it does confuse red4-conflicts a bit.