### PR TITLE
Fix FF7 remake crash when no mods are selected

### DIFF
--- a/games/game_finalfantasy7remake.py
+++ b/games/game_finalfantasy7remake.py
@@ -47,6 +47,8 @@ class FinalFantasy7RemakeGame(BasicGame, mobase.IPluginFileMapper):
                 yield mods_parent_path / mod
 
     def _active_mod_mappings(self, mod_paths: List[Path]) -> Iterable[mobase.Mapping]:
+        if not mod_paths:
+            return
         pak_priority_digits = math.floor(math.log10(len(mod_paths))) + 1
 
         for priority, mod_path in enumerate(mod_paths):


### PR DESCRIPTION
In function `_active_mod_mappings`, `pak_priority_digits` was calculated based on log base 10 of number of mod paths for selected mods. When no mods are selected (or no paths present in selected mods), this takes log(0) resulting in a ValueError. But `pak_priority_digits` is not needed in this case, so this commit fixes by early exiting in case of no mod paths prior to computing `pak_priority_digits`.

Example crash:
![image](https://github.com/user-attachments/assets/05f65ea8-de00-441c-81f0-8ac58a3b7ce8)
