### PR TITLE
Add / extend game detection support for Epic Games (Heroic Games Launcher)

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,7 +206,8 @@ Game IDs can be found here:
 - For Origin from `C:\ProgramData\Origin\LocalContent` (.mfst files)
 - For Epic Games (`AppName`) from:
   - `C:\ProgramData\Epic\EpicGamesLauncher\Data\Manifests\` (.item files)
-  - or: `C:\ProgramData\Epic\EpicGamesLauncher\UnrealEngineLauncher\LauncherInstalled.dat`
+  - or `C:\ProgramData\Epic\EpicGamesLauncher\UnrealEngineLauncher\LauncherInstalled.dat`
+  - or [Unofficial EGS ID DB](https://erri120.github.io/egs-db/)
 - For Legendary (alt. Epic launcher) via command `legendary list-games`
     or from: `%USERPROFILE%\.config\legendary\installed.json`
 - For EA Desktop from `<EA Games install location>\<game title>\__Installer\installerdata.xml`

--- a/epic_utils.py
+++ b/epic_utils.py
@@ -16,11 +16,11 @@ def find_epic_games() -> Iterable[tuple[str, Path]]:
             winreg.HKEY_LOCAL_MACHINE,
             r"Software\Wow6432Node\Epic Games\EpicGamesLauncher",
         ) as key:
-            epic_app_data_path, _ = winreg.QueryValueEx(key, "AppDataPath")
+            epic_data_path, _ = winreg.QueryValueEx(key, "AppDataPath")
     except FileNotFoundError:
-        return
+        epic_data_path = r"%ProgramData%\Epic\EpicGamesLauncher\Data"
 
-    manifests_path = Path(os.path.expandvars(epic_app_data_path)).joinpath("Manifests")
+    manifests_path = Path(os.path.expandvars(epic_data_path)).joinpath("Manifests")
     if manifests_path.exists():
         for manifest_file_path in manifests_path.glob("*.item"):
             try:

--- a/epic_utils.py
+++ b/epic_utils.py
@@ -38,10 +38,10 @@ def find_epic_games() -> Iterable[tuple[str, Path]]:
                 )
 
 
-def find_legendary_games() -> Iterable[tuple[str, Path]]:
+def find_legendary_games(config_path: str | None = None) -> Iterable[tuple[str, Path]]:
     # Based on legendary source:
     # https://github.com/derrod/legendary/blob/master/legendary/lfs/lgndry.py
-    if config_path := os.environ.get("XDG_CONFIG_HOME"):
+    if config_path := config_path or os.environ.get("XDG_CONFIG_HOME"):
         legendary_config_path = Path(config_path, "legendary")
     else:
         legendary_config_path = Path("~/.config/legendary").expanduser()
@@ -61,8 +61,14 @@ def find_legendary_games() -> Iterable[tuple[str, Path]]:
             )
 
 
+def find_heroic_games():
+    return find_legendary_games(os.path.expandvars(r"%AppData%\heroic\legendaryConfig"))
+
+
 def find_games() -> dict[str, Path]:
-    return dict(itertools.chain(find_epic_games(), find_legendary_games()))
+    return dict(
+        itertools.chain(find_epic_games(), find_legendary_games(), find_heroic_games())
+    )
 
 
 if __name__ == "__main__":

--- a/games/game_control.py
+++ b/games/game_control.py
@@ -16,6 +16,7 @@ class ControlGame(BasicGame):
     GameNexusId = 2936
     GameSteamId = 870780
     GameGogId = 2049187585
+    GameEpicId = "calluna"
     GameBinary = "Control.exe"
     GameDataPath = ""
 

--- a/games/game_cyberpunk2077.py
+++ b/games/game_cyberpunk2077.py
@@ -201,6 +201,7 @@ class Cyberpunk2077Game(BasicGame):
     GameSaveExtension = "dat"
     GameSteamId = 1091500
     GameGogId = 1423049311
+    GameEpicId = "77f2b98e2cef40c8a7437518bf420e47"
     GameSupportURL = (
         r"https://github.com/ModOrganizer2/modorganizer-basic_games/wiki/"
         "Game:-Cyberpunk-2077"

--- a/games/game_subnautica-below-zero.py
+++ b/games/game_subnautica-below-zero.py
@@ -13,6 +13,7 @@ class SubnauticaBelowZeroGame(game_subnautica.SubnauticaGame):
     GameShortName = "subnauticabelowzero"
     GameNexusName = "subnauticabelowzero"
     GameSteamId = 848450
+    GameEpicId = "foxglove"
     GameBinary = "SubnauticaZero.exe"
     GameDataPath = "_ROOT"
     GameDocumentsDirectory = "%GAME_PATH%"


### PR DESCRIPTION
- Add detection of Epic Game Store games installed via [Heroic Games Launcher](https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher).
- Fix detection for EGS installed games (synced in ProgramData)
- Add [Unofficial EGS ID DB](https://erri120.github.io/egs-db/) to the README
- Add EGS IDs to: Subnautica Below Zero, Cyberpunk, Control

Note: games with different savegame paths, like existing Subnatica support, would require an exposed API for correct path selection, e.g. via `.gameVariant()`