### PR TITLE
Catch and show game list errors at startup

### DIFF
--- a/basic_game.py
+++ b/basic_game.py
@@ -8,6 +8,7 @@ from typing import Callable, Generic, TypeVar
 import mobase
 from PyQt6.QtCore import QDir, QFileInfo, QStandardPaths
 from PyQt6.QtGui import QIcon
+from PyQt6.QtWidgets import QMessageBox
 
 from .basic_features.basic_save_game_info import (
     BasicGameSaveGame,
@@ -380,11 +381,22 @@ class BasicGame(mobase.IPluginGame):
         from .origin_utils import find_games as find_origin_games
         from .steam_utils import find_games as find_steam_games
 
+        errors: list[tuple[str, Exception]] = []
         BasicGame.steam_games = find_steam_games()
         BasicGame.gog_games = find_gog_games()
         BasicGame.origin_games = find_origin_games()
-        BasicGame.epic_games = find_epic_games()
-        BasicGame.eadesktop_games = find_eadesktop_games()
+        BasicGame.epic_games = find_epic_games(errors)
+        BasicGame.eadesktop_games = find_eadesktop_games(errors)
+
+        if errors:
+            QMessageBox.critical(
+                None,
+                "Errors loading game list",
+                (
+                    "The following errors occurred while loading the list of available games:\n"
+                    f"\n- {'\n\n- '.join('\n '.join(str(e) for e in messageError) for messageError in errors)}"
+                ),
+            )
 
     # File containing the plugin:
     _fromName: str

--- a/games/game_sims4.py
+++ b/games/game_sims4.py
@@ -111,6 +111,8 @@ class TS4ModDataChecker(ModDataChecker):
                             ValidationResult.FIXABLE,
                             lambda: tree.move(entry, innerPath),
                         )
+                    case _:
+                        pass
             return walkReturn
 
         tree.walk(fixOrValidateEntry)


### PR DESCRIPTION
- Catches errors while loading the game list (EA and Epic/Heroic/Legendary Games)
- Shows an error message at MO start with details about the problematic files and how to solve the problem
- Fixes lint errors (from #173 ?)

Remarks:
- I appended the original error message (without the stack trace), but one could also only log it and hide it from the message.
- This message will show up at every MO start until the files are either fixed or deleted. There is no option to hide it, since at this loading stage, there is no access to plugin options (`IOrganizer`)  or similar.

Example error message:
![Error_loading_game_list](https://github.com/user-attachments/assets/856fc549-ffb5-4ff9-9a84-5daadbd6b3d6)

Extends #154