### PR TITLE
Add basic support for Dark Souls II Scholar of the First Sin

### DIFF
--- a/games/game_darksouls2sotfs.py
+++ b/games/game_darksouls2sotfs.py
@@ -1,0 +1,22 @@
+from ..basic_game import BasicGame
+
+
+class DarkSouls2SotfsGame(BasicGame):
+    Name = "DarkSouls2Sotfs"
+    Author = "raehik"
+    Version = "0.1.0"
+
+    GameName = "Dark Souls II: Scholar of the First Sin"
+    GameShortName = "darksouls2sotfs"
+    GameNexusName = "darksouls2"
+    GameNexusId = 482
+    GameSteamId = 335300
+    GameBinary = "Game/DarkSoulsII.exe"
+    GameDataPath = "Game"
+    GameDocumentsDirectory = "%USERPROFILE%/AppData/Roaming/DarkSoulsII"
+    GameSavesDirectory = "%USERPROFILE%/AppData/Roaming/DarkSoulsII"
+    GameSaveExtension = "sl2"
+    GameSupportURL = (
+        r"https://github.com/ModOrganizer2/modorganizer-basic_games/wiki/"
+        "Game:-Dark-Souls-2-Sotfs"
+    )


### PR DESCRIPTION
Dark Souls has basic support. Dark Souls II does not. I believe it's worthwhile, since it has been on Nexus Mods for many years. Many recent mods use a framework provided by DS2LE (a graphical overhaul) to override textures and such. It's filesystem-based. This is exactly what ModOrganizer is great at :)

I copied the Dark Souls plugin, tweaked some bits, and have been using for a handful of mods without issue.