### PR TITLE
fix check for if directory is packable in baldursgate3.pak_parser

### DIFF
--- a/games/baldursgate3/pak_parser.py
+++ b/games/baldursgate3/pak_parser.py
@@ -11,12 +11,13 @@ from typing import Callable
 from xml.etree import ElementTree
 from xml.etree.ElementTree import Element
 
-import mobase
 from PyQt6.QtCore import (
     qDebug,
     qInfo,
     qWarning,
 )
+
+import mobase
 
 from . import bg3_utils
 


### PR DESCRIPTION
the check currently fails and will create paks out of things like regular files and directories that do not match. This fixes that.