### PR TITLE
Valheim: fix BepInEx installation, missing file .doorstop_version

### DIFF
--- a/games/game_valheim.py
+++ b/games/game_valheim.py
@@ -318,6 +318,7 @@ class ValheimGame(BasicGame):
                         "BepInEx",
                         "doorstop_libs",
                         "unstripped_corlib",
+                        ".doorstop_version",
                         "doorstop_config.ini",
                         "start_game_bepinex.sh",
                         "start_server_bepinex.sh",


### PR DESCRIPTION
Missing file in `ModDataChecker`: `.doorstop_version`