### PR TITLE
fix(bg3): write modsettings backup as utf-8 and avoid home-relative path errors in log cleanup

### DIFF
--- a/games/baldursgate3/bg3_utils.py
+++ b/games/baldursgate3/bg3_utils.py
@@ -250,7 +250,8 @@ class BG3Utils:
                     if mod.name() in metadata
                 )
                 + self._mod_settings_xml_end
-            )
+            ),
+            encoding="utf-8",
         )
         qInfo(
             f"backing up generated file {self.modsettings_path} to {self.modsettings_backup}, "

--- a/games/game_baldursgate3.py
+++ b/games/game_baldursgate3.py
@@ -167,6 +167,13 @@ class BG3Game(BasicGame, bg3_file_mapper.BG3FileMapper):
         base_bin = Path(self.gameDirectory().absoluteFilePath("bin"))
         return {str(f.relative_to(base_bin)) for f in base_bin.glob("*.dll")}
 
+    @staticmethod
+    def _format_debug_path(path: Path) -> Path:
+        try:
+            return path.relative_to(Path.home())
+        except ValueError:
+            return path
+
     def _on_finished_run(self, exec_path: str, exit_code: int):
         if "bin/bg3" not in exec_path:
             return
@@ -190,8 +197,8 @@ class BG3Game(BasicGame, bg3_file_mapper.BG3FileMapper):
         moved: dict[str, str] = {}
         for path in self.utils.overwrite_path.rglob("*.log"):
             try:
-                moved[str(path.relative_to(Path.home()))] = str(
-                    (self.utils.log_dir / path.name).relative_to(Path.home())
+                moved[str(self._format_debug_path(path))] = str(
+                    self._format_debug_path(self.utils.log_dir / path.name)
                 )
                 path.replace(self.utils.log_dir / path.name)
             except PermissionError as e:
@@ -201,8 +208,8 @@ class BG3Game(BasicGame, bg3_file_mapper.BG3FileMapper):
             if path.name == "log.txt":
                 dest = self.utils.log_dir / f"{path.parent.name}-{path.name}"
             try:
-                moved[str(path.relative_to(Path.home()))] = str(
-                    dest.relative_to(Path.home())
+                moved[str(self._format_debug_path(path))] = str(
+                    self._format_debug_path(dest)
                 )
                 path.replace(dest)
             except PermissionError as e:
@@ -230,10 +237,10 @@ class BG3Game(BasicGame, bg3_file_mapper.BG3FileMapper):
             for folder in sorted(list(fdir.walk(top_down=False)))[:-1]:
                 try:
                     folder[0].rmdir()
-                    removed.add(folder[0].relative_to(Path.home()))
+                    removed.add(self._format_debug_path(folder[0]))
                 except OSError:
                     pass
             if cat is not None and cat.isDebugEnabled() and len(removed) > 0:
                 qDebug(
-                    f"cleaned empty dirs from {fdir.relative_to(Path.home())} {removed}"
+                    f"cleaned empty dirs from {self._format_debug_path(fdir)} {removed}"
                 )


### PR DESCRIPTION
Fix 2 errors:
- Write modsettings backup as utf-8
- Avoid home-relative path errors in log cleanup