### PR TITLE
fix(sts2): create mods directory if missing

### DIFF
--- a/games/game_sts2.py
+++ b/games/game_sts2.py
@@ -30,7 +30,7 @@ class SlayTheSpire2ModDataChecker(BasicModDataChecker):
 class SlayTheSpire2Game(BasicGame):
     Name = "Slay the Spire 2 Support Plugin"
     Author = "Azlle"
-    Version = "1.0.0"
+    Version = "1.0.1"
 
     GameName = "Slay the Spire 2"
     GameShortName = "slaythespire2"

--- a/games/game_sts2.py
+++ b/games/game_sts2.py
@@ -46,6 +46,11 @@ class SlayTheSpire2Game(BasicGame):
         self._register_feature(SlayTheSpire2ModDataChecker())
         return True
 
+    def initializeProfile(self, directory: QDir, settings: mobase.ProfileSetting):
+        mods_path = Path(self.dataDirectory().absolutePath())
+        mods_path.mkdir(exist_ok=True)
+        super().initializeProfile(directory, settings)
+
     def savesDirectory(self) -> QDir:
         docs = QDir(self.documentsDirectory())
         steam_dir = Path(docs.absoluteFilePath("steam"))


### PR DESCRIPTION
Creates the `mods/` directory specified in `GameDataPath` via `initializeProfile()` if it doesn't exist, preventing a 0xc0000034 error on data reload.