### PR TITLE
[Baldur's Gate 3]: Fix UnicodeEncodeError and ValueError

### DIFF
--- a/games/baldursgate3/bg3_utils.py
+++ b/games/baldursgate3/bg3_utils.py
@@ -250,7 +250,8 @@ class BG3Utils:
                     if mod.name() in metadata
                 )
                 + self._mod_settings_xml_end
-            )
+            ),
+            encoding="utf-8",
         )
         qInfo(
             f"backing up generated file {self.modsettings_path} to {self.modsettings_backup}, "

--- a/games/game_baldursgate3.py
+++ b/games/game_baldursgate3.py
@@ -190,9 +190,7 @@ class BG3Game(BasicGame, bg3_file_mapper.BG3FileMapper):
         moved: dict[str, str] = {}
         for path in self.utils.overwrite_path.rglob("*.log"):
             try:
-                moved[str(path.relative_to(Path.home()))] = str(
-                    (self.utils.log_dir / path.name).relative_to(Path.home())
-                )
+                moved[str(path)] = str((self.utils.log_dir / path.name))
                 path.replace(self.utils.log_dir / path.name)
             except PermissionError as e:
                 qDebug(str(e))
@@ -201,9 +199,7 @@ class BG3Game(BasicGame, bg3_file_mapper.BG3FileMapper):
             if path.name == "log.txt":
                 dest = self.utils.log_dir / f"{path.parent.name}-{path.name}"
             try:
-                moved[str(path.relative_to(Path.home()))] = str(
-                    dest.relative_to(Path.home())
-                )
+                moved[str(path)] = str(dest)
                 path.replace(dest)
             except PermissionError as e:
                 qDebug(str(e))
@@ -230,10 +226,8 @@ class BG3Game(BasicGame, bg3_file_mapper.BG3FileMapper):
             for folder in sorted(list(fdir.walk(top_down=False)))[:-1]:
                 try:
                     folder[0].rmdir()
-                    removed.add(folder[0].relative_to(Path.home()))
+                    removed.add(folder[0])
                 except OSError:
                     pass
             if cat is not None and cat.isDebugEnabled() and len(removed) > 0:
-                qDebug(
-                    f"cleaned empty dirs from {fdir.relative_to(Path.home())} {removed}"
-                )
+                qDebug(f"cleaned empty dirs from {fdir} {removed}")

--- a/games/game_divinityoriginalsin.py
+++ b/games/game_divinityoriginalsin.py
@@ -32,8 +32,6 @@ class DivinityOriginalSinGame(BasicGame):
     def init(self, organizer: mobase.IOrganizer):
         super().init(organizer)
         self._register_feature(
-            BasicGameSaveGameInfo(
-                lambda s: s.with_suffix(".png")  # Not confirmed
-            )
+            BasicGameSaveGameInfo(lambda s: s.with_suffix(".png"))  # Not confirmed
         )
         return True


### PR DESCRIPTION
Reported by a tester on Discord:
<img width="502" height="256" alt="imagen" src="https://github.com/user-attachments/assets/3a6f55dc-f05f-4943-a892-c0c169475d7a" />
<img width="502" height="256" alt="imagen" src="https://github.com/user-attachments/assets/d7afb8df-6465-4675-8202-2db57093d6eb" />
According to this line:
https://github.com/ModOrganizer2/modorganizer-basic_games/blob/3262f22ed81430f7d4bae00c86d50ac912c1ea21/games/baldursgate3/bg3_utils.py#L52
The XML file uses UTF-8 encoding, so that needs to be taken into account when writing the file.

The `ValueError` is caused by the `path.relative_to(Path.home())` calls, which assume that MO2 is installed in the user's home directory, but that's not always the case. These paths seem to only be used for debugging purposes, so I just removed the `relative_to` part.