### PR TITLE
Fix wrong GOG Id for Darkest Dungeon

### DIFF
--- a/games/game_darkestdungeon.py
+++ b/games/game_darkestdungeon.py
@@ -166,7 +166,7 @@ class DarkestDungeonGame(BasicGame):
     GameNexusName = "darkestdungeon"
     GameNexusId = 804
     GameSteamId = 262060
-    GameGogId = 1719198803
+    GameGogId = 1450711444
     GameBinary = "_windows/win64/Darkest.exe"
     GameDataPath = ""
     GameDocumentsDirectory = "%DOCUMENTS%/Darkest"


### PR DESCRIPTION
Due to the wrong GOG ID, creating a new instance for Darkest Dungeon picks up Kingdom Come Deliverance.

<img width="423" height="189" alt="image" src="https://github.com/user-attachments/assets/0cba87c1-3eb0-4d16-9cff-0af52302a772" />

References:
Darkest Dungeon: https://www.gogdb.org/product/1450711444
Kingdom Come Deliverance: https://www.gogdb.org/product/1719198803