### PR TITLE
Fix small typo in FF7 Rebirth plugin name

### DIFF
--- a/games/game_finalfantasy7rebirth.py
+++ b/games/game_finalfantasy7rebirth.py
@@ -83,7 +83,7 @@ class FinalFantasy7RebirthFileManager:
 
 
 class FinalFantasy7RebirthGame(BasicGame, mobase.IPluginFileMapper):
-    Name = "Final Fasntasy 7 Rebirth Support Plugin"
+    Name = "Final Fantasy 7 Rebirth Support Plugin"
     Author = "diegofesanto, TheUnlocked"
     Version = "0.0.1"
 


### PR DESCRIPTION
Fix small typo in FF7 Rebirth plugin name: Fasntasy -> Fantasy