### PR TITLE
Paralives - Content Mod support

### DIFF
--- a/games/game_paralives.py
+++ b/games/game_paralives.py
@@ -3,28 +3,30 @@ from ..basic_game import BasicGame
 
 
 class ParalivesGame(BasicGame):
-    #Plugin name
+    # Plugin name
     Name = "Paralives"
     Author = "Julian Noel"
     Version = "0.1.0"
 
-    #actual game name
+    # actual game name
     GameName = "Paralives"
 
     # Internal game ID used by MO2
     GameShortName = "paralives"
-    
+
     # The nexus mods page identifier (if applicable)
     GameNexusName = "paralives"
-    
+
     # The main executable MO2 will look for to verify the folder
     GameBinary = "Paralives.exe"
 
-    #TODO
+    # TODO
     GameDocumentsDirectory = "%USERPROFILE%/AppData/LocalLow/Paralives/Paralives"
-    GameSavesDirectory = "%USERPROFILE%/AppData/LocalLow/Paralives/Paralives/MySavedGames.mod"
+    GameSavesDirectory = (
+        "%USERPROFILE%/AppData/LocalLow/Paralives/Paralives/MySavedGames.mod"
+    )
 
-    #framework includes special variables like %GAME_DOCUMENTS% to override the 
+    # framework includes special variables like %GAME_DOCUMENTS% to override the
     # default relative path semantics; absolute paths will be treated as absolutes
     # relatives will be done relative to the actual game directory
     GameDataPath = "%GAME_DOCUMENTS%"
@@ -34,8 +36,7 @@ class ParalivesGame(BasicGame):
     # maybe - it's actually really hard to find this
     GameNexusId = 9002
 
-
-    #TODO: save handling (it is in the localappdata folder but should be excluded)
+    # TODO: save handling (it is in the localappdata folder but should be excluded)
 
     def __init__(self):
         super().__init__()
@@ -61,8 +62,8 @@ class ParalivesGame(BasicGame):
         #             #
         #             "AdvancedBuilder",
         #         ],
-        #         # mod authors will add these but they 
-        #         # are not needed for deployment and will often 
+        #         # mod authors will add these but they
+        #         # are not needed for deployment and will often
         #         # conflict with each other anyway.
         #         delete=[
         #             #readmes, helpers, etc
@@ -78,7 +79,7 @@ class ParalivesGame(BasicGame):
         #             "*.pdb",
         #         ],
         #         #TODO: check basic_games to see if expanded variables work here
-        #         #we need to move these files into the 
+        #         #we need to move these files into the
         #         # bepinex dirs instead of the default location
         #         move={
         #             # part of BepInEx script mod support
@@ -91,5 +92,4 @@ class ParalivesGame(BasicGame):
         #     )
         # )
 
-    #TODO: savegame handling (since it lives in the same folder as the content mods but is NOT a content mod)
-
+    # TODO: savegame handling (since it lives in the same folder as the content mods but is NOT a content mod)

--- a/games/game_paralives.py
+++ b/games/game_paralives.py
@@ -6,7 +6,7 @@ class ParalivesGame(BasicGame):
     # Plugin name
     Name = "Paralives"
     Author = "Julian Noel"
-    Version = "0.1.0"
+    Version = "0.1.1"
 
     # actual game name
     GameName = "Paralives"
@@ -21,7 +21,7 @@ class ParalivesGame(BasicGame):
     GameBinary = "Paralives.exe"
 
     # TODO
-    GameDocumentsDirectory = "%USERPROFILE%/AppData/LocalLow/Paralives/Paralives"
+    GameDocumentsDirectory = "%USERPROFILE%/AppData/LocalLow/Paralives/Paralives/ModOrganizer"
     GameSavesDirectory = (
         "%USERPROFILE%/AppData/LocalLow/Paralives/Paralives/MySavedGames.mod"
     )

--- a/games/game_paralives.py
+++ b/games/game_paralives.py
@@ -1,0 +1,95 @@
+from ..basic_features import BasicModDataChecker, GlobPatterns
+from ..basic_game import BasicGame
+
+
+class ParalivesGame(BasicGame):
+    #Plugin name
+    Name = "Paralives"
+    Author = "Julian Noel"
+    Version = "0.1.0"
+
+    #actual game name
+    GameName = "Paralives"
+
+    # Internal game ID used by MO2
+    GameShortName = "paralives"
+    
+    # The nexus mods page identifier (if applicable)
+    GameNexusName = "paralives"
+    
+    # The main executable MO2 will look for to verify the folder
+    GameBinary = "Paralives.exe"
+
+    #TODO
+    GameDocumentsDirectory = "%USERPROFILE%/AppData/LocalLow/Paralives/Paralives"
+    GameSavesDirectory = "%USERPROFILE%/AppData/LocalLow/Paralives/Paralives/MySavedGames.mod"
+
+    #framework includes special variables like %GAME_DOCUMENTS% to override the 
+    # default relative path semantics; absolute paths will be treated as absolutes
+    # relatives will be done relative to the actual game directory
+    GameDataPath = "%GAME_DOCUMENTS%"
+
+    # Steam App ID for auto-detection
+    GameSteamId = 1119730
+    # maybe - it's actually really hard to find this
+    GameNexusId = 9002
+
+
+    #TODO: save handling (it is in the localappdata folder but should be excluded)
+
+    def __init__(self):
+        super().__init__()
+        self._featureMap[mobase.ModDataChecker] = BasicModDataChecker(
+            #describe what operation, and what matches to perform them on
+            GlobPatterns(
+                #valid files findable in a mod
+                valid=[
+                    "meta.ini",  # Included in installed mod folder.
+                    "BepInEx",
+                    "doorstop_libs",
+                    "unstripped_corlib",
+                    "doorstop_config.ini",
+                    "start_game_bepinex.sh",
+                    "start_server_bepinex.sh",
+                    "winhttp.dll",
+                    #
+                    "InSlimVML",
+                    "Paralives_Data",
+                    "inslimvml.ini",
+                    #
+                    "unstripped_managed",
+                    #
+                    "AdvancedBuilder",
+                ],
+                # mod authors will add these but they 
+                # are not needed for deployment and will often 
+                # conflict with each other anyway.
+                delete=[
+                    #readmes, helpers, etc
+                    "*.txt",
+                    "*.md",
+                    "README",
+                    "icon.png",
+                    "license",
+                    #package crap
+                    "manifest.json",
+                    #debug crap
+                    "*.dll.mdb",
+                    "*.pdb",
+                ],
+                #TODO: check basic_games to see if expanded variables work here
+                #we need to move these files into the 
+                # bepinex dirs instead of the default location
+                move={
+                    # part of BepInEx script mod support
+                    "plugins": "BepInEx/",
+                    "*.dll": "BepInEx/plugins/",
+                    "*.xml": "BepInEx/plugins/",
+                    "config": "BepInEx/",
+                    "*.cfg": "BepInEx/config/",
+                }
+            )
+        )
+
+    #TODO: savegame handling (since it lives in the same folder as the content mods but is NOT a content mod)
+

--- a/games/game_paralives.py
+++ b/games/game_paralives.py
@@ -1,4 +1,4 @@
-from ..basic_features import BasicModDataChecker, GlobPatterns
+# from ..basic_features import BasicModDataChecker, GlobPatterns
 from ..basic_game import BasicGame
 
 
@@ -39,57 +39,57 @@ class ParalivesGame(BasicGame):
 
     def __init__(self):
         super().__init__()
-        self._featureMap[mobase.ModDataChecker] = BasicModDataChecker(
-            #describe what operation, and what matches to perform them on
-            GlobPatterns(
-                #valid files findable in a mod
-                valid=[
-                    "meta.ini",  # Included in installed mod folder.
-                    "BepInEx",
-                    "doorstop_libs",
-                    "unstripped_corlib",
-                    "doorstop_config.ini",
-                    "start_game_bepinex.sh",
-                    "start_server_bepinex.sh",
-                    "winhttp.dll",
-                    #
-                    "InSlimVML",
-                    "Paralives_Data",
-                    "inslimvml.ini",
-                    #
-                    "unstripped_managed",
-                    #
-                    "AdvancedBuilder",
-                ],
-                # mod authors will add these but they 
-                # are not needed for deployment and will often 
-                # conflict with each other anyway.
-                delete=[
-                    #readmes, helpers, etc
-                    "*.txt",
-                    "*.md",
-                    "README",
-                    "icon.png",
-                    "license",
-                    #package crap
-                    "manifest.json",
-                    #debug crap
-                    "*.dll.mdb",
-                    "*.pdb",
-                ],
-                #TODO: check basic_games to see if expanded variables work here
-                #we need to move these files into the 
-                # bepinex dirs instead of the default location
-                move={
-                    # part of BepInEx script mod support
-                    "plugins": "BepInEx/",
-                    "*.dll": "BepInEx/plugins/",
-                    "*.xml": "BepInEx/plugins/",
-                    "config": "BepInEx/",
-                    "*.cfg": "BepInEx/config/",
-                }
-            )
-        )
+        # self._featureMap[mobase.ModDataChecker] = BasicModDataChecker(
+        #     #describe what operation, and what matches to perform them on
+        #     GlobPatterns(
+        #         #valid files findable in a mod
+        #         valid=[
+        #             "meta.ini",  # Included in installed mod folder.
+        #             "BepInEx",
+        #             "doorstop_libs",
+        #             "unstripped_corlib",
+        #             "doorstop_config.ini",
+        #             "start_game_bepinex.sh",
+        #             "start_server_bepinex.sh",
+        #             "winhttp.dll",
+        #             #
+        #             "InSlimVML",
+        #             "Paralives_Data",
+        #             "inslimvml.ini",
+        #             #
+        #             "unstripped_managed",
+        #             #
+        #             "AdvancedBuilder",
+        #         ],
+        #         # mod authors will add these but they 
+        #         # are not needed for deployment and will often 
+        #         # conflict with each other anyway.
+        #         delete=[
+        #             #readmes, helpers, etc
+        #             "*.txt",
+        #             "*.md",
+        #             "README",
+        #             "icon.png",
+        #             "license",
+        #             #package crap
+        #             "manifest.json",
+        #             #debug crap
+        #             "*.dll.mdb",
+        #             "*.pdb",
+        #         ],
+        #         #TODO: check basic_games to see if expanded variables work here
+        #         #we need to move these files into the 
+        #         # bepinex dirs instead of the default location
+        #         move={
+        #             # part of BepInEx script mod support
+        #             "plugins": "BepInEx/",
+        #             "*.dll": "BepInEx/plugins/",
+        #             "*.xml": "BepInEx/plugins/",
+        #             "config": "BepInEx/",
+        #             "*.cfg": "BepInEx/config/",
+        #         }
+        #     )
+        # )
 
     #TODO: savegame handling (since it lives in the same folder as the content mods but is NOT a content mod)
 

--- a/games/game_paralives.py
+++ b/games/game_paralives.py
@@ -21,7 +21,9 @@ class ParalivesGame(BasicGame):
     GameBinary = "Paralives.exe"
 
     # TODO
-    GameDocumentsDirectory = "%USERPROFILE%/AppData/LocalLow/Paralives/Paralives/ModOrganizer"
+    GameDocumentsDirectory = (
+        "%USERPROFILE%/AppData/LocalLow/Paralives/Paralives/ModOrganizer"
+    )
     GameSavesDirectory = (
         "%USERPROFILE%/AppData/LocalLow/Paralives/Paralives/MySavedGames.mod"
     )


### PR DESCRIPTION
## Objective
- [x] Creation of Paralives MO2 instances
- [x] Game boots from MO2
- [x] VFS points to Paralives local mod folder
- [x] Can add and correctly map content mods (.mod folders) 
- [x] Content mods in instance work when Paralives is booted from the instance
- [x] `MySavedGames.mod` directory is correctly handled (currently being incorrectly treated as an Override)
- [x] `MyOptions.mod` directory is correctly handled (currently being incorrectly treated as an Override)
- [x] The vanilla `MyPremadeXX.mod` directories are handled correctly
- [x] Interfaces with Nexus Mods (downloads correctly, archives handled, categories import)

## Known Issues
- Steam overlay does not appear
  - Steam workshop mods still appear to work correctly though
- Mod formatting not yet checked/sanitized with globs; most mod structures work fine, but some may need to be adjusted after/during mod install

## Challenges
Paralives has a neat yet curious structure, where any and every change to the base engine is treated as a "mod", including game options ("modding" default settings to other values), save games ("modding" the default town state, adding Paras, lots, etc). As a result, the game places them in the same folder as other "traditional" mods.

The VFS seemingly needs to be adapted to either exclude these subfolders from the VFS entirely, or to at least correctly exclude changes to them from falling into Overrides so that non-mod data persists correctly.

## Upcoming Plans

After this PR, the next target is implementing support for BepInEx, which appears to be the current solution for implementing script mods in Paralives. 

Those mods live in an entirely different root (under the game directory, whereas the local mods folder lives under `%LocalAppData%Low/Paralives/Paralives`